### PR TITLE
[bug] '/town’ 경로로 접속 차단 및 리다이렉트 필요 

### DIFF
--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -10,7 +10,10 @@ import { UsersPanel } from "@/widgets/usersPanel";
 
 import { useEffect } from "react";
 
+import { useRouter } from "next/navigation";
+
 export default function TownPage() {
+  const router = useRouter();
   const { data: user, isLoading } = useUserInfo();
   const userNickname = user?.user_metadata?.nickname;
   const { setUserNickname } = useUserStore();
@@ -23,13 +26,19 @@ export default function TownPage() {
     }
   }, [setUserNickname, userNickname]);
 
+  useEffect(() => {
+    if (!isLoading && !userNickname) {
+      router.push("/");
+    }
+  }, [isLoading, userNickname, router]);
+
   const nicknameFallback = (
     <div className="flex h-full items-center justify-center text-gray-500">
       닉네임을 설정해주세요.
     </div>
   );
 
-  if (isLoading) {
+  if (isLoading || !userNickname) {
     return (
       <div className="flex h-screen flex-col items-center justify-center overflow-hidden">
         <p>사용자 정보를 불러오는 중...</p>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

이슈 #43 긴급 픽스입니다.

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**

우선은 간단하게 타운 페이지에
useRouter().push("/")로 가드를 걸어둘 예정입니다.

다만 현재 타운 페이지가 클라이언트 컴포넌트라
/town 화면이 한 번 렌더링된 뒤에야 리다이렉트가 일어나는 바람에
조금 느리게 느껴지는 문제가 있어요.

이걸 제대로 해결하려면 타운 페이지를 서버 컴포넌트로 전환해야 하는데,
그 과정에서 리팩토링할 부분이 꽤 많아서
다음 phase에서 정리하는 게 좋을 것 같습니다!

- **함께 고민하고 싶은 부분:**
- **기타 참고사항:**
