### PR TITLE
refactor(chat): 스크롤 로직 개선 및 새 메시지 감지 추가 (#84)

### DIFF
--- a/src/features/chat/ui/ChatHistory.tsx
+++ b/src/features/chat/ui/ChatHistory.tsx
@@ -41,7 +41,6 @@ export default function ChatHistory({
   const prevScrollTop = useRef<number>(0);
 
   const [skeletonCount, setSkeletonCount] = useState(DEFAULT_SKELETON_COUNT);
-  const [isAtBottom, setIsAtBottom] = useState(true);
 
   const sortedMessages = useMemo(() => {
     return [...messages].sort((a, b) => {
@@ -115,13 +114,27 @@ export default function ChatHistory({
     isFirstRender.current = false;
   }, [sortedMessages]);
 
+  // 스크롤 임계값 (px)
+  const SCROLL_THRESHOLD = 20;
+  const lastMessageIdRef = useRef<number | null>(null);
+  // TODO: step3 작업 단계에서 hasNewMessage를 배지/버튼에 연결 예정
+  const [, setHasNewMessage] = useState(false);
+  const isAtBottomRef = useRef(true);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
     const handleScroll = () => {
-      const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 5;
-      setIsAtBottom(atBottom);
+      const { scrollHeight, scrollTop, clientHeight } = container;
+      const isBottom = scrollHeight - scrollTop - clientHeight <= SCROLL_THRESHOLD;
+
+      isAtBottomRef.current = isBottom;
+
+      // 사용자가 직접 맨 아래로 스크롤하면 알림 끄기
+      if (isBottom) {
+        setHasNewMessage(false);
+      }
     };
 
     container.addEventListener("scroll", handleScroll);
@@ -131,9 +144,28 @@ export default function ChatHistory({
   }, []);
 
   useEffect(() => {
-    if (!isAtBottom) return;
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, isAtBottom]);
+    if (sortedMessages.length === 0) return;
+
+    const lastMsg = sortedMessages[sortedMessages.length - 1];
+    const isNewMessageObj = lastMessageIdRef.current !== lastMsg.id;
+    if (!isNewMessageObj) return;
+
+    if (isFirstRender.current) {
+      lastMessageIdRef.current = lastMsg.id;
+      return;
+    }
+
+    if (isAtBottomRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      lastMessageIdRef.current = lastMsg.id;
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      setHasNewMessage(true);
+    });
+    lastMessageIdRef.current = lastMsg.id;
+  }, [sortedMessages]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
close #84 

# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

채팅 히스토리의 스크롤 감지 및 새 메시지 추적 로직을 안정화했습니다.
UI 변경 없이 내부 로직만 먼저 정리한 단계입니다.

-    스크롤 하단 감지 임계값을 `5px -> 20px`로 조정하여 하단 판정 안정화
-   `lastMessageIdRef`를 도입해 단순 스크롤/리렌더와 실제 새 메시지 도착을 구분
-   `isAtBottomRef` 기준으로 자동 스크롤 분기 처리
    -    하단에 있으면 새 메시지 도착 시 자동 스크롤
    -    하단이 아니면 자동 스크롤하지 않고 새 메시지 상태만 갱신
-   향후 UI 연결을 위한 `hasNewMessage` 상태 로직 추가 (step3에서 연결 예정)

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
  `src/features/chat/ui/ChatHistory.tsx`의 새 메시지 판별 조건(`lastMessageIdRef`)과 자동 스크롤 분기
  로직을 확인해주세요.

- **함께 고민하고 싶은 부분:**
  step3에서 `hasNewMessage`를 UI에 연결할 때 메시지 개수(`newMessageCount`)를 같이 관리하는게 좋을까요?

- **기타 참고사항:**
  이번 PR은 로직 안정화만 포함하며, 새 메시지 알림 UI 연결은 별도 단계(step3)에서 진행 예정입니다.
