### PR TITLE
feat(chat): 새 메시지 알림 UI 및 애니메이션 추가

### DIFF
--- a/src/features/chat/ui/ChatHistory.tsx
+++ b/src/features/chat/ui/ChatHistory.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Message, MessagesPage } from "../types";
 import { ChatMessageItem } from "./ChatMessageItem";
 import { DateDivider } from "./DateDivider";
+import { NewMessageNotification } from "./NewMessageNotification";
 import { ObservedMessageWrapper } from "./ObservedMessageWrapper";
 
 interface ChatHistoryProps {
@@ -42,6 +43,7 @@ export default function ChatHistory({
 
   const [skeletonCount, setSkeletonCount] = useState(DEFAULT_SKELETON_COUNT);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const [debugShowNotification, setDebugShowNotification] = useState(true);
 
   const sortedMessages = useMemo(() => {
     return [...messages].sort((a, b) => {
@@ -170,40 +172,57 @@ export default function ChatHistory({
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="border-b px-3 py-2 text-sm font-semibold">채팅</div>
 
-      <div ref={containerRef} className="flex flex-1 flex-col overflow-y-auto p-3 text-sm">
-        {isLoading ? (
-          <ChatMessageSkeletonList count={skeletonCount} />
-        ) : sortedMessages.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center text-gray-500">
-            대화를 시작해보세요!
-          </div>
-        ) : (
-          <>
-            {hasMore && <div ref={topObserverRef} className="h-1" />}
-            {isFetchingNextPage && <ChatMessageSkeletonList count={skeletonCount} />}
-            {messagesWithPageIndex.map((message, index) => {
-              const prevMessage = index > 0 ? messagesWithPageIndex[index - 1] : undefined;
-              const isFirstMessage = index === 0;
-              const isDifferentDay =
-                prevMessage && !isSameDay(prevMessage.created_at, message.created_at);
+      <div className="relative flex min-h-0 flex-1">
+        {/* TODO: 새 메시지 연결 작업 전까지 애니메이션 확인용 디버그 토글 */}
+        <button
+          type="button"
+          onClick={() => setDebugShowNotification((prev) => !prev)}
+          className="absolute top-2 right-2 z-20 rounded-md border bg-background px-2 py-1 text-xs"
+        >
+          Toggle Notification
+        </button>
+        <div ref={containerRef} className="flex h-full flex-col overflow-y-auto p-3 text-sm">
+          {isLoading ? (
+            <ChatMessageSkeletonList count={skeletonCount} />
+          ) : sortedMessages.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center text-gray-500">
+              대화를 시작해보세요!
+            </div>
+          ) : (
+            <>
+              {hasMore && <div ref={topObserverRef} className="h-1" />}
+              {isFetchingNextPage && <ChatMessageSkeletonList count={skeletonCount} />}
+              {messagesWithPageIndex.map((message, index) => {
+                const prevMessage = index > 0 ? messagesWithPageIndex[index - 1] : undefined;
+                const isFirstMessage = index === 0;
+                const isDifferentDay =
+                  prevMessage && !isSameDay(prevMessage.created_at, message.created_at);
 
-              const showDateDivider =
-                shouldShowDateDividers && ((isFirstMessage && !isLoading) || isDifferentDay);
+                const showDateDivider =
+                  shouldShowDateDividers && ((isFirstMessage && !isLoading) || isDifferentDay);
 
-              return (
-                <ObservedMessageWrapper
-                  key={`message-${message.id}`}
-                  pageIndex={message.pageIndex}
-                  observer={observer.current}
-                >
-                  {showDateDivider && <DateDivider created_at={message.created_at} />}
-                  <ChatMessageItem message={message} previousMessage={prevMessage} />
-                </ObservedMessageWrapper>
-              );
-            })}
-          </>
-        )}
-        <div ref={messagesEndRef} />
+                return (
+                  <ObservedMessageWrapper
+                    key={`message-${message.id}`}
+                    pageIndex={message.pageIndex}
+                    observer={observer.current}
+                  >
+                    {showDateDivider && <DateDivider created_at={message.created_at} />}
+                    <ChatMessageItem message={message} previousMessage={prevMessage} />
+                  </ObservedMessageWrapper>
+                );
+              })}
+            </>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* UI 테스트를 위한 임시 렌더링 */}
+        <NewMessageNotification
+          show={debugShowNotification}
+          count={3}
+          onClick={() => setDebugShowNotification(false)}
+        />
       </div>
     </div>
   );

--- a/src/features/chat/ui/NewMessageNotification.tsx
+++ b/src/features/chat/ui/NewMessageNotification.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Button } from "@/shared/ui/button";
+import { ArrowDown } from "lucide-react";
+
+/**
+ * 새 메시지 알림 컴포넌트
+ *
+ * 사용자가 스크롤을 올려서 과거 메시지를 보고 있을 때,
+ * 새 메시지가 도착하면 하단에 표시되는 알림 버튼입니다.
+ * 클릭 시 스크롤을 맨 아래로 이동시키는 동작을 수행합니다.
+ */
+
+interface NewMessageNotificationProps {
+  onClick: () => void;
+  show: boolean;
+  count?: number;
+}
+
+export function NewMessageNotification({ onClick, show, count = 0 }: NewMessageNotificationProps) {
+  return (
+    <div
+      className={`absolute right-4 -bottom-0 z-10 transition-all duration-300 sm:right-5 sm:-bottom-0 ${
+        show
+          ? "pointer-events-none translate-y-0 scale-100 opacity-100 animate-in fade-in zoom-in-95 slide-in-from-bottom-2"
+          : "pointer-events-none translate-y-2 scale-95 opacity-0 animate-out fade-out zoom-out-95 slide-out-to-bottom-2"
+      }`}
+      aria-hidden={!show}
+    >
+      <Button
+        onClick={onClick}
+        className="pointer-events-auto cursor-pointer gap-2 rounded-full bg-primary/85 shadow-lg backdrop-blur-sm"
+        size="sm"
+        aria-label={`새 메시지 ${count}개`}
+        tabIndex={show ? 0 : -1}
+      >
+        <ArrowDown size={16} />
+        <span>
+          새 메시지 <strong className="text-amber-300">{count}개</strong>
+        </span>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
close #85 

# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

새 메시지 알림 UI를 구현하고, 위치/문구/시각적 표현을 조정했습니다.
  이번 단계는 UI 중심 작업이며, 실제 로직 연결은 step3에서 진행합니다.

  - `NewMessageNotification` 컴포넌트 추가 및 스타일링 적용
  - 버튼 문구를 간결하게 구성: `새 메시지 n개`
  - 메시지 개수(`count`)를 포인트 컬러로 강조
  - 버튼 배경 반투명 처리(`bg-primary/85`) 및 블러 효과 적용(`backdrop-blur-sm`)
  - 클릭 가능한 요소임을 명확히 하기 위해 `cursor-pointer` 적용
  - 우측 고정 배치 및 여백 조정
  - 등장/퇴장 모션 보강 (fade/slide/scale 전환)
  - 접근성 보완 (`aria-label`, 숨김 상태 포커스 제어)

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [x] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

![new_message_button_animation](https://github.com/user-attachments/assets/01f99528-e763-4108-8261-2166260688d0)


## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
  `src/features/chat/ui/NewMessageNotification.tsx`의 위치 고정 방식과 애니메이션 강도(등장/퇴장 체감)

- **함께 고민하고 싶은 부분:**
  step3에서 새 메시지 개수는 아래처럼 단순하게 가져가려고 합니다.

  1.   사용자가 채팅 하단에 없을 때 새 메시지가 오면 개수를 1씩 올립니다.
  2.   사용자가 하단으로 돌아오면(직접 스크롤 또는 알림 버튼 클릭) 개수를 0으로 초기화합니다.
  3.   같은 메시지가 중복 집계되지 않도록 마지막 집계 메시지 ID를 기준으로 처리합니다.

- **기타 참고사항:**
  현재 `ChatHistory`에는 애니메이션 확인용 임시 토글 코드가 포함되어 있으며, step3 연결 작업에서 최종
  제거 예정입니다. 
  step3는 step1과 step2가 머지된 develop 브랜치를 기준으로 만들 예정입니다. 