### PR TITLE
feat: 채팅 realtime 채널을 빌리지 단위로 전환 (#95)

### DIFF
--- a/src/shared/config/supabase.client.ts
+++ b/src/shared/config/supabase.client.ts
@@ -1,6 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
 
-export const CHAT_CHANNEL_NAME = "public:chat-room";
 export const CHAT_TABLE_NAME = "chat";
 
 /**

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -6,4 +6,5 @@ export {
   runGarbageCollection,
 } from "./chat";
 export { toDate, isSameDay, formatTime, formatDate, formatJoinedTime } from "./datetime";
+export { getChatChannelName } from "./realtime/getChatChannelName";
 export { getChatRoomId } from "./realtime/getChatRoomId";

--- a/src/shared/lib/realtime/getChatChannelName.ts
+++ b/src/shared/lib/realtime/getChatChannelName.ts
@@ -1,5 +1,5 @@
 /**
  * 빌리지별 채팅 Realtime channel name을 생성합니다.
- * chat room_id와는 별개로, 채팅 구독 토픽을 채팅 전용 네임스페이스로 분리합니다.
+ * chat room_id와는 별개이며, movement/presence 등과 같이 village 기준(`village:${villageId}`) 아래 하위 토픽 `chat`을 둡니다.
  */
-export const getChatChannelName = (villageId: string): string => `chat:village:${villageId}`;
+export const getChatChannelName = (villageId: string): string => `village:${villageId}:chat`;

--- a/src/shared/lib/realtime/getChatChannelName.ts
+++ b/src/shared/lib/realtime/getChatChannelName.ts
@@ -1,0 +1,5 @@
+/**
+ * 빌리지별 채팅 Realtime channel name을 생성합니다.
+ * chat room_id와는 별개로, 채팅 구독 토픽을 채팅 전용 네임스페이스로 분리합니다.
+ */
+export const getChatChannelName = (villageId: string): string => `chat:village:${villageId}`;

--- a/src/shared/lib/realtime/index.ts
+++ b/src/shared/lib/realtime/index.ts
@@ -2,6 +2,7 @@
 // 실시간 통신 관련 유틸리티
 
 export * from "./channel";
+export * from "./getChatChannelName";
 
 // 비즈니스 로직 레이어
 // export { createSupabaseClient } from './supabaseClient';

--- a/src/widgets/chatPanel/model/useChatPanel.ts
+++ b/src/widgets/chatPanel/model/useChatPanel.ts
@@ -13,7 +13,6 @@ import {
   runGarbageCollection,
 } from "@/shared/lib";
 import { useChatVisibilityActions, useUserStore, useVisiblePageIndices } from "@/shared/store";
-import { RealtimeChannel } from "@supabase/supabase-js";
 import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -37,7 +36,7 @@ export function useChatPanel() {
   const chatChannelName = getChatChannelName(villageId);
   const roomId = getChatRoomId(villageId);
 
-  const [channel, setChannel] = useState<RealtimeChannel | null>(null);
+  const [channelStatus, setChannelStatus] = useState("INITIAL");
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
 
   // Zustand 스토어 사용
@@ -54,6 +53,13 @@ export function useChatPanel() {
   if (prevRoomId !== roomId) {
     setPrevRoomId(roomId);
     setOptimisticMessages([]);
+  }
+
+  // 빌리지 전환 시 이전 채널 상태를 현재 UI에 남기지 않도록 렌더 중 비교로 초기화합니다.
+  const [prevChatChannelName, setPrevChatChannelName] = useState(chatChannelName);
+  if (prevChatChannelName !== chatChannelName) {
+    setPrevChatChannelName(chatChannelName);
+    setChannelStatus("INITIAL");
   }
 
   // GC Trigger: 페이지 수가 너무 많아지면 정리 (Infinite Scroll 등으로 인해)
@@ -122,6 +128,8 @@ export function useChatPanel() {
   useEffect(() => {
     if (!userNickname || !supabase) return;
 
+    let isActive = true;
+
     const chatChannel = supabase.channel(chatChannelName);
 
     chatChannel
@@ -143,12 +151,12 @@ export function useChatPanel() {
         },
       )
       .subscribe((status) => {
-        if (status === "SUBSCRIBED") {
-          setChannel(chatChannel);
-        }
+        if (!isActive) return;
+        setChannelStatus(status);
       });
 
     return () => {
+      isActive = false;
       supabase.removeChannel(chatChannel);
     };
   }, [chatChannelName, userNickname, supabase, queryClient, roomId]);
@@ -190,7 +198,7 @@ export function useChatPanel() {
     messages,
     data,
     handleMessageSend,
-    isConnected: !!channel,
+    isConnected: channelStatus === "SUBSCRIBED",
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,

--- a/src/widgets/chatPanel/model/useChatPanel.ts
+++ b/src/widgets/chatPanel/model/useChatPanel.ts
@@ -4,7 +4,7 @@ import { useSupabase } from "@/app/providers/SupabaseProvider";
 import { Message, MessagesPage } from "@/features/chat";
 import { useMessagesQuery } from "@/features/chat/hooks/useMessagesQuery";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
-import { CHAT_CHANNEL_NAME, CHAT_GC_CONFIG, CHAT_TABLE_NAME } from "@/shared/config";
+import { CHAT_GC_CONFIG, CHAT_TABLE_NAME } from "@/shared/config";
 import {
   addMessageToCache,
   getChatRoomId,
@@ -16,6 +16,8 @@ import { RealtimeChannel } from "@supabase/supabase-js";
 import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+
+const DEFAULT_CHAT_REALTIME_CHANNEL = "public:chat-room";
 
 /**
  * 채팅 패널의 주요 비즈니스 로직을 관리하는 커스텀 훅입니다.
@@ -120,7 +122,7 @@ export function useChatPanel() {
   useEffect(() => {
     if (!userNickname || !supabase) return;
 
-    const chatChannel = supabase.channel(CHAT_CHANNEL_NAME);
+    const chatChannel = supabase.channel(DEFAULT_CHAT_REALTIME_CHANNEL);
 
     chatChannel
       .on(

--- a/src/widgets/chatPanel/model/useChatPanel.ts
+++ b/src/widgets/chatPanel/model/useChatPanel.ts
@@ -26,7 +26,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
  * - 가비지 컬렉션(GC) 로직 트리거
  * - 메시지 전송 및 낙관적 업데이트(Optimistic Updates)
  * - 읽은 메시지(뷰포트 내 페이지)의 타임스탬프 갱신
- * - 빌리지별 채팅 채널 분리 (room_id: village:${villageId})
+ * - 빌리지별 채팅 채널 분리 (room_id: village:${villageId}, Realtime topic: getChatChannelName)
  */
 export function useChatPanel() {
   const supabase = useSupabase();

--- a/src/widgets/chatPanel/model/useChatPanel.ts
+++ b/src/widgets/chatPanel/model/useChatPanel.ts
@@ -7,6 +7,7 @@ import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { CHAT_GC_CONFIG, CHAT_TABLE_NAME } from "@/shared/config";
 import {
   addMessageToCache,
+  getChatChannelName,
   getChatRoomId,
   removeMatchingTempMessage,
   runGarbageCollection,
@@ -16,8 +17,6 @@ import { RealtimeChannel } from "@supabase/supabase-js";
 import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-
-const DEFAULT_CHAT_REALTIME_CHANNEL = "public:chat-room";
 
 /**
  * 채팅 패널의 주요 비즈니스 로직을 관리하는 커스텀 훅입니다.
@@ -35,6 +34,7 @@ export function useChatPanel() {
   const queryClient = useQueryClient();
   const { userId, userNickname } = useUserStore();
   const villageId = useMovementStore((state) => state.villageId);
+  const chatChannelName = getChatChannelName(villageId);
   const roomId = getChatRoomId(villageId);
 
   const [channel, setChannel] = useState<RealtimeChannel | null>(null);
@@ -122,7 +122,7 @@ export function useChatPanel() {
   useEffect(() => {
     if (!userNickname || !supabase) return;
 
-    const chatChannel = supabase.channel(DEFAULT_CHAT_REALTIME_CHANNEL);
+    const chatChannel = supabase.channel(chatChannelName);
 
     chatChannel
       .on(
@@ -151,7 +151,7 @@ export function useChatPanel() {
     return () => {
       supabase.removeChannel(chatChannel);
     };
-  }, [userNickname, supabase, queryClient, roomId]);
+  }, [chatChannelName, userNickname, supabase, queryClient, roomId]);
 
   const handleMessageSend = async (messageText: string): Promise<{ error?: string }> => {
     if (!messageText || !userNickname || !userId) return {};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

**채팅 realtime 채널을 빌리지 단위로 전환 (Issue 2)**

https://github.com/seoyoonyi/dopaminetto/issues/70 이슈를 4개의 하위 이슈로 분리하였으며, 본 PR은 그중 두번째 단위 작업인 
채팅 Realtime 구독을 고정 채널에서 빌리지 단위 채널로 전환 작업에 해당합니다.

 - 채팅 구독의 공용 `CHAT_CHANNEL_NAME` 의존성을 제거했습니다.
  - `getChatChannelName(villageId)`를 추가해 채팅 Realtime topic을 `chat:village:
  ${villageId}` 규칙으로 분리했습니다.
  - `useChatPanel`에서 현재 `villageId` 기준으로 채널명을 계산하고, 해당 채널에 구독하도록
  변경했습니다.
  - 채널 연결 상태를 `subscription status` 기반으로 관리하도록 정리해 빌리지 전환 시 이전
  채널 상태가 남지 않도록 수정했습니다.
  - 기존 `room_id` 기반 조회/전송/Realtime filter 로직은 유지했습니다.

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
  - `useChatPanel`의 채널 상태 초기화와 빌리지 전환 시 subscription status 처리 방식이 의도에 맞게 구성되었는지 확인 부탁드립니다.
- **함께 고민하고 싶은 부분:**
  -  채팅 channel naming을 `chat:village:${villageId}`로 적용했는데, 기존 `village:${villageId} `계열 규칙과의 일관성을 고려하면 `village:${villageId}:chat` 형태가 더 적절한지 함께 의견 부탁드립니다.
- **기타 참고사항:**