### PR TITLE
feat: 채팅 UI에 현재 빌리지 채널 상태 표시 (#97)

### DIFF
--- a/src/features/chat/ui/MessageField.tsx
+++ b/src/features/chat/ui/MessageField.tsx
@@ -9,7 +9,7 @@ import { ChangeEvent, KeyboardEvent, useState } from "react";
 import { CharacterCounter } from "./CharacterCounter";
 
 interface MessageFieldProps {
-  channelType: "public" | "private";
+  channelType?: "public" | "private";
   onMessageSend?: (message: string) => Promise<{ error?: string }>;
   isConnected: boolean;
   roomId: string;
@@ -26,7 +26,7 @@ const MAX_LENGTH = 1000;
 const WRAPPER_PADDING = 24;
 
 export default function MessageField({
-  channelType,
+  channelType = "public",
   onMessageSend,
   isConnected,
   roomId,

--- a/src/widgets/chatPanel/model/useChatPanel.ts
+++ b/src/widgets/chatPanel/model/useChatPanel.ts
@@ -205,5 +205,6 @@ export function useChatPanel() {
     isLoading,
     onVisiblePagesUpdate: updateVisiblePagesTimestamp,
     roomId,
+    villageId,
   };
 }

--- a/src/widgets/chatPanel/ui/ChatPanel.tsx
+++ b/src/widgets/chatPanel/ui/ChatPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { VILLAGES } from "@/entities/village";
 import { ChatHistory, MessageField } from "@/features/chat";
 
 import { useChatPanel } from "../model/useChatPanel";
+import { ChatPanelHeader } from "./ChatPanelHeader";
 
 export function ChatPanel() {
   const {
@@ -17,11 +19,16 @@ export function ChatPanel() {
     isFetchingNextPage,
     onVisiblePagesUpdate,
     roomId,
+    villageId,
   } = useChatPanel();
+
+  const villageName = VILLAGES[villageId as keyof typeof VILLAGES]?.name ?? villageId;
 
   return (
     <>
+      <ChatPanelHeader villageName={villageName} isConnected={isConnected} />
       <ChatHistory
+        key={roomId}
         messages={messages}
         data={data}
         onLoadMore={fetchNextPage}
@@ -31,12 +38,7 @@ export function ChatPanel() {
         onVisiblePagesUpdate={onVisiblePagesUpdate}
         currentUserId={userId}
       />
-      <MessageField
-        channelType="public"
-        onMessageSend={handleMessageSend}
-        isConnected={isConnected}
-        roomId={roomId}
-      />
+      <MessageField onMessageSend={handleMessageSend} isConnected={isConnected} roomId={roomId} />
     </>
   );
 }

--- a/src/widgets/chatPanel/ui/ChatPanelHeader.tsx
+++ b/src/widgets/chatPanel/ui/ChatPanelHeader.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface ChatPanelHeaderProps {
+  villageName: string;
+  isConnected: boolean;
+}
+
+export function ChatPanelHeader({ villageName, isConnected }: ChatPanelHeaderProps) {
+  return (
+    <div className="flex items-center gap-2 border-b px-3 py-2">
+      <span
+        className={cn(
+          "size-2 rounded-full shrink-0",
+          isConnected ? "bg-green-500" : "bg-yellow-400",
+        )}
+      />
+      <span className="text-sm font-medium truncate">{villageName} 채널</span>
+      {!isConnected && <span className="text-xs text-muted-foreground shrink-0">연결 중...</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
**채팅 UI에 현재 빌리지 채널 상태 표시(issue 4)**

https://github.com/seoyoonyi/dopaminetto/issues/70 이슈를 4개의 하위 이슈로 분리하였으며, 본 PR은 그중 마지막 단위 작업인
채팅 UI에 현재 빌리지 채널 상태 표시 작업에 해당합니다.

- ChatPanelHeader 컴포넌트 추가: 빌리지 채널명과 연결 상태 dot 표시를 했습니다.
- ChatPanel에서 villageId → villageName 변환 후 ChatPanelHeader에 전달하였습니다.
- ChatHistory에 key={roomId} 추가로 채널 전환 시 상태 자동 초기화를 진행하였습니다.
- useChatPanel 반환값에 villageId를 추가하였습니다.
- MessageField의 channelType prop을 optional로 변경하였습니다. (기본값: "public")

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)
[issue-97-demo.webm](https://gist.github.com/user-attachments/assets/769998ff-22f0-474b-8536-7bbca9dcc596)


## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:** 
  - `ChatHistory`에 추가한 `key={roomId}` — 채널 전환 시 이전 스크롤 상태가 남지 않도록 ChatHistory에 key={roomId}를 넣었습니다. 이로 인해 재마운트가 발생하므로 성능 영향이 없는지 함께 확인 부탁드립니다.
- **함께 고민하고 싶은 부분:** 
  - `VILLAGES` 상수에 없는 `villageId`가 들어올 경우 현재는 ID 문자열을 그대로 표시하고 있습니다. 이 경우 사용자에게 더 자연스러운 대체 문구(예: 알 수 없는 채널)가 나을지 의견 부탁드립니다.
- **기타 참고사항** 
  - 이슈 #95  에서 내부 로직(채널명/roomId 계산)은 이미 빌리지 단위로 전환되어 있었으며, 이번 PR은 그 정보를 UI에 노출하는 마무리 작업입니다.
  - 이슈 #96 은 검증 결과 이슈 #95에서 이미 충족되어 추가 코드 변경이 필요하지 않아 이 PR에서는 제외했습니다. 이 내용은 해당 이슈 코멘트에도 작성해두었습니다!
