### PR TITLE
fix(voice-chat): 잘못된 preset 설정으로 인한 404 에러 수정

### DIFF
--- a/src/app/api/voice/token/route.ts
+++ b/src/app/api/voice/token/route.ts
@@ -2,10 +2,10 @@
 import { NextResponse } from "next/server";
 
 /** speaker용 Cloudflare Realtime Kit preset Name */
-const SPEAKER_PRESET_NAME = "livestream_host";
+const SPEAKER_PRESET_NAME = "group_call_host";
 
 /** listener용 Cloudflare Realtime Kit preset Name */
-const LISTENER_PRESET_NAME = "livestream_viewer";
+const LISTENER_PRESET_NAME = "group_call_participant";
 
 /** 음성 토큰 발급 요청 바디 */
 type VoiceTokenRequest = {

--- a/src/features/presence/ui/PresenceToolbarButton.tsx
+++ b/src/features/presence/ui/PresenceToolbarButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/shared/ui/button";
-import { Users } from "lucide-react";
+import { Mic, MicOff, Users, Volume2, VolumeX } from "lucide-react";
 
 import { useTownPresenceStore } from "../model/useTownPresenceStore";
 
@@ -16,6 +16,16 @@ export const PresenceToolbarButton = ({
 }: PresenceToolbarButtonProps) => {
   const participantCount = useTownPresenceStore((state) => state.participants.length);
   const isConnected = useTownPresenceStore((state) => state.isConnected);
+
+  const canToggleAudio = useTownPresenceStore((state) => state.canToggleAudio);
+  const toggleLocalAudio = useTownPresenceStore((state) => state.toggleLocalAudio);
+  const audioEnabled = useTownPresenceStore((state) => state.audioEnabled);
+  const isAudioToggling = useTownPresenceStore((state) => state.isAudioToggling);
+
+  const canToggleListening = useTownPresenceStore((state) => state.canToggleListening);
+  const toggleLocalListening = useTownPresenceStore((state) => state.toggleLocalListening);
+  const listeningEnabled = useTownPresenceStore((state) => state.listeningEnabled);
+
   const toggleLabel = isUsersPanel ? "채팅 패널로 보기" : "사용자 패널로 보기";
   const toggleText = isUsersPanel ? "채팅" : "사용자";
   const connectionIndicatorClass = `h-2 w-2 rounded-full ${
@@ -23,32 +33,87 @@ export const PresenceToolbarButton = ({
   }`;
   const connectionIndicatorText = isConnected ? "연결됨" : "연결 끊김";
 
+  const handleToggleAudio = () => {
+    if (!canToggleAudio || !toggleLocalAudio || isAudioToggling) return;
+    void toggleLocalAudio();
+  };
+
+  const handleToggleListening = () => {
+    if (!canToggleListening || !toggleLocalListening) return;
+    void toggleLocalListening();
+  };
+
   return (
-    <Button
-      type="button"
-      variant={isUsersPanel ? "default" : "outline"}
-      size="sm"
-      aria-pressed={isUsersPanel}
-      aria-label={toggleLabel}
-      onClick={onToggle}
-      className={`flex h-10 min-w-[145px] items-center justify-between gap-2 rounded-full px-4 text-sm font-medium transition-colors shadow-sm ${
-        isUsersPanel
-          ? "border border-gray-900 bg-gray-900 text-white"
-          : "border bg-white text-gray-700"
-      }`}
-    >
-      <Users className="h-4 w-4" aria-hidden />
-      <span>{participantCount}</span>
-      <span className="hidden sm:inline">{toggleText}</span>
-      <span
-        className={`flex items-center gap-1 text-[11px] font-normal ${
-          isUsersPanel ? "text-gray-300" : "text-gray-500"
+    <div className="flex items-center justify-end gap-2">
+      {canToggleAudio ? (
+        <Button
+          type="button"
+          variant={audioEnabled ? "default" : "outline"}
+          size="sm"
+          aria-label={audioEnabled ? "마이크 끄기" : "마이크 켜기"}
+          aria-pressed={audioEnabled}
+          disabled={!toggleLocalAudio || isAudioToggling}
+          onClick={handleToggleAudio}
+          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
+        >
+          {audioEnabled ? (
+            <Mic className="h-4 w-4" aria-hidden />
+          ) : (
+            <MicOff className="h-4 w-4" aria-hidden />
+          )}
+          <span>{audioEnabled ? "방송 중" : "마이크 켜기"}</span>
+        </Button>
+      ) : null}
+
+      {canToggleListening ? (
+        <Button
+          type="button"
+          variant={listeningEnabled ? "default" : "outline"}
+          size="sm"
+          aria-label={listeningEnabled ? "청취 중지" : "청취 시작"}
+          aria-pressed={listeningEnabled}
+          disabled={!toggleLocalListening}
+          onClick={handleToggleListening}
+          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
+        >
+          {listeningEnabled ? (
+            <Volume2 className="h-4 w-4" aria-hidden />
+          ) : (
+            <VolumeX className="h-4 w-4" aria-hidden />
+          )}
+          <span>{listeningEnabled ? "청취 중" : "청취 시작"}</span>
+        </Button>
+      ) : null}
+
+      <Button
+        type="button"
+        variant={isUsersPanel ? "default" : "outline"}
+        size="sm"
+        aria-pressed={isUsersPanel}
+        aria-label={toggleLabel}
+        onClick={onToggle}
+        className={`flex h-10 min-w-[145px] items-center justify-between gap-2 rounded-full px-4 text-sm font-medium transition-colors shadow-sm ${
+          isUsersPanel
+            ? "border border-gray-900 bg-gray-900 text-white"
+            : "border bg-white text-gray-700"
         }`}
-        aria-live="polite"
       >
-        <span className={connectionIndicatorClass} aria-hidden />
-        <span>{connectionIndicatorText}</span>
-      </span>
-    </Button>
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4" aria-hidden />
+          <span>{participantCount}</span>
+          <span className="hidden sm:inline">{toggleText}</span>
+        </div>
+
+        <span
+          className={`flex items-center gap-1 text-[11px] font-normal ${
+            isUsersPanel ? "text-gray-300" : "text-gray-500"
+          }`}
+          aria-live="polite"
+        >
+          <span className={connectionIndicatorClass} aria-hidden />
+          <span>{connectionIndicatorText}</span>
+        </span>
+      </Button>
+    </div>
   );
 };

--- a/src/features/voice-chat/ui/TownVoiceClient.tsx
+++ b/src/features/voice-chat/ui/TownVoiceClient.tsx
@@ -58,8 +58,8 @@ type ConnectionStatus =
 /**
  * 음성 채널 연결이 완료된 뒤 speaker/listener 역할에 맞는 UI를 렌더링한다.
  *
- * speaker는 마이크 토글을 노출하고,
- * listener는 방송자의 오디오만 재생한다.
+ * speaker는 마이크 상태 안내를 보여주고,
+ * listener는 speaker의 오디오를 재생한다.
  */
 function VoicePanel({
   isSpeaker,
@@ -97,10 +97,11 @@ function VoicePanel({
               ? "현재 방송을 청취합니다."
               : "사용자 패널의 헤드셋 버튼으로 청취를 시작할 수 있습니다."}
           </p>
+          <p>isListeningEnabled: {String(isListeningEnabled)}</p>
         </div>
       )}
       {/* 모든 역할에서 상대방 오디오를 재생한다. listener는 헤드셋 토글 상태를 따른다. */}
-      {isSpeaker || isListeningEnabled ? <RtkParticipantsAudio /> : null}
+      {isSpeaker || isListeningEnabled ? <RtkParticipantsAudio meeting={meeting} /> : null}
     </section>
   );
 }
@@ -126,8 +127,9 @@ export function TownVoiceClient({
   const [status, setStatus] = useState<ConnectionStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [tokenResult, setTokenResult] = useState<RequestVoiceTokenResponse | null>(null);
-  const [isListeningEnabled, setIsListeningEnabled] = useState(true);
+  const [isListeningEnabled, setIsListeningEnabled] = useState(false);
   const [localAudioEnabled, setLocalAudioEnabled] = useState(false);
+
   const meetingRef = useRef<typeof client | null>(null);
   const listeningEnabledRef = useRef(true);
   /** 마이크 토글 SDK 호출이 진행 중인지 동기적으로 추적하는 ref.
@@ -156,9 +158,10 @@ export function TownVoiceClient({
         onAudioTogglingChange?.(false);
         onAudioControllerChange?.(false, null);
         onListeningControllerChange?.(false, null);
-        listeningEnabledRef.current = true;
-        setIsListeningEnabled(true);
-        onListeningEnabledChange?.(true);
+
+        listeningEnabledRef.current = false;
+        setIsListeningEnabled(false);
+        onListeningEnabledChange?.(false);
 
         const tokenResponse = await requestVoiceToken({
           userId,
@@ -171,7 +174,11 @@ export function TownVoiceClient({
         setTokenResult(tokenResponse);
         setStatus("initializing");
 
-        const mediaHandler = await initRTKMedia({ audio: false, video: false });
+        const mediaHandler = await initRTKMedia({
+          audio: canUseMic,
+          video: false,
+        });
+
         const initializedMeeting = await initMeeting({
           authToken: tokenResponse.token,
           defaults: {
@@ -256,19 +263,34 @@ export function TownVoiceClient({
         await initializedMeeting.joinRoom();
         joinedRoom = true;
 
+        console.log("self.roomJoined", initializedMeeting.self.roomJoined);
+        console.log("self.audioEnabled(before)", initializedMeeting.self.audioEnabled);
+        console.log("mediaPermissions(before)", initializedMeeting.self.mediaPermissions);
+
         if (!isMounted) return;
 
         if (!canUseMic && initializedMeeting.self.audioEnabled) {
           await initializedMeeting.self.disableAudio();
         }
 
+        console.log("participants.joined", initializedMeeting.participants.joined);
+        console.log(
+          "participants.audioSubscribed",
+          initializedMeeting.participants.audioSubscribed,
+        );
+
         onAudioControllerChange?.(canUseMic, canUseMic ? toggleLocalAudio : null);
         onListeningControllerChange?.(!isSpeaker, !isSpeaker ? toggleLocalListening : null);
 
         if (canUseMic) {
           try {
+            console.log("mediaPermissions(before)", initializedMeeting.self.mediaPermissions);
             await initializedMeeting.self.enableAudio();
+            console.log("self.audioEnabled(after)", initializedMeeting.self.audioEnabled);
+            console.log("mediaPermissions(after)", initializedMeeting.self.mediaPermissions);
           } catch (audioError) {
+            console.error("enableAudio error", audioError);
+            console.log("mediaPermissions(error)", initializedMeeting.self.mediaPermissions);
             if (isMounted) {
               setErrorMessage(
                 audioError instanceof Error


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

**1. 타운 음성 채널 참여 시 (active-livestream 관련) 404 에러 수정**
- **원인**: 음성 채널 권한에 사용된 `livestream_host` / `livestream_viewer` preset은 RTMP 외부 스트리밍 전용이라 SDK 내부에서 지속적으로 `active-livestream` API를 호출하며 404 에러를 발생시킴을 확인하였습니다.
- **해결**: 타운 내 다대다/일대다 음성 소통 목적에 맞는 `group_call_host` / `group_call_participant` preset으로 변경하여 404 에러 해결 하였습니다!

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
- **함께 고민하고 싶은 부분:**
- **기타 참고사항:**
