### PR TITLE
[feature] 플레이어 위치 영속 저장 및 재접속 시 복원

### DIFF
--- a/src/features/movement/hooks/useRestorePlayerPosition.ts
+++ b/src/features/movement/hooks/useRestorePlayerPosition.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { VillageId } from "@/entities/village";
+import { fetchPlayerPosition } from "@/features/movement/lib/playerPositionService";
+import { isValidSavedPosition } from "@/features/movement/lib/validateMovement";
+import { useMovementStore } from "@/features/movement/model/useMovementStore";
+import { useUserInfo } from "@/shared/hooks/useUserInfo";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 접속 시 Supabase user_position 테이블에서 마지막 저장 위치를 조회하고,
+ * 유효하면 스토어에 초기 위치로 적용한다.
+ *
+ * isReady가 true가 되기 전까지 엔진 마운트를 보류해
+ * 기본 위치에 잠깐 나타났다가 저장 위치로 이동하는 텔레포트 현상을 방지한다.
+ */
+export function useRestorePlayerPosition() {
+  const [isReady, setIsReady] = useState(false);
+  const { data: user, isLoading: isUserLoading } = useUserInfo();
+  const initializePosition = useMovementStore((state) => state.initializePosition);
+
+  useEffect(() => {
+    // 유저 정보 로딩 중에는 대기
+    if (isUserLoading) return;
+
+    // async IIFE로 감싸 setState가 마이크로태스크에서 호출되도록 한다.
+    // (useEffect 내 동기 setState는 불필요한 렌더 연쇄를 유발할 수 있다)
+    void (async () => {
+      try {
+        if (user) {
+          const saved = await fetchPlayerPosition(user.id);
+
+          if (saved && isValidSavedPosition(saved.village_id, { x: saved.x, y: saved.y })) {
+            // 유효한 저장 위치가 있으면 스토어에 반영
+            initializePosition({ x: saved.x, y: saved.y }, saved.village_id as VillageId);
+          }
+          // 저장 위치가 없거나 유효하지 않으면 기본 스폰 위치(로비) 유지
+        }
+      } catch (err) {
+        // 조회 실패 시 기본 위치로 진입, 실패는 로깅
+        console.error("[useRestorePlayerPosition] 위치 조회 실패:", err);
+      } finally {
+        // 성공/실패 모두 엔진 마운트를 허용
+        setIsReady(true);
+      }
+    })();
+  }, [user, isUserLoading, initializePosition]);
+
+  return { isReady };
+}

--- a/src/features/movement/hooks/useSavePlayerPosition.ts
+++ b/src/features/movement/hooks/useSavePlayerPosition.ts
@@ -86,7 +86,7 @@ export function useSavePlayerPosition(enabled: boolean) {
     }
   };
 
-  // 1. 5초 주기 저장 - 위치가 변경된 경우에만 실행
+  // 1. 5초 주기 저장 - 검증 완료 좌표(lastSyncedPosition) 기준
   useEffect(() => {
     if (!enabled || !user) return;
 
@@ -98,7 +98,7 @@ export function useSavePlayerPosition(enabled: boolean) {
     return () => clearInterval(interval);
   }, [enabled, user]);
 
-  // 2. 빌리지 이동 시 즉시 저장
+  // 2. 빌리지 이동 시 즉시 저장 - 검증 완료 좌표(lastSyncedPosition) 기준
   useEffect(() => {
     if (!enabled || !user) return;
 
@@ -111,7 +111,7 @@ export function useSavePlayerPosition(enabled: boolean) {
     );
   }, [enabled, user]);
 
-  // 3. 페이지 이탈(새로고침/탭 닫기) 시 best-effort 저장
+  // 3. 페이지 이탈(새로고침/탭 닫기) 시 best-effort 저장 - 최신 화면 좌표(position) 기준
   // keepalive fetch를 사용해 페이지가 언로드된 후에도 요청이 완료될 수 있도록 한다.
   useEffect(() => {
     if (!enabled || !user) return;

--- a/src/features/movement/hooks/useSavePlayerPosition.ts
+++ b/src/features/movement/hooks/useSavePlayerPosition.ts
@@ -33,6 +33,8 @@ export function useSavePlayerPosition(enabled: boolean) {
   const lastSavedRef = useRef<SaveState | null>(null);
   // 동시 저장 요청 방지 플래그
   const isSavingRef = useRef(false);
+  // 저장 중 들어온 요청을 보류했다가 완료 후 재실행하기 위한 플래그
+  const pendingSaveRef = useRef(false);
   // pagehide 시 동기적으로 접근해야 해서 ref에 캐싱
   const accessTokenRef = useRef<string | null>(null);
 
@@ -51,7 +53,11 @@ export function useSavePlayerPosition(enabled: boolean) {
 
   // 위치가 변경된 경우에만 저장하는 내부 함수
   const trySave = async (userId: string, villageId: VillageId, position: Position) => {
-    if (isSavingRef.current) return;
+    if (isSavingRef.current) {
+      // 저장 중에 들어온 요청은 드롭하지 않고 보류 — 완료 후 재실행
+      pendingSaveRef.current = true;
+      return;
+    }
 
     const rx = Math.round(position.x);
     const ry = Math.round(position.y);
@@ -71,6 +77,12 @@ export function useSavePlayerPosition(enabled: boolean) {
       console.error("[useSavePlayerPosition] 저장 실패:", err);
     } finally {
       isSavingRef.current = false;
+      if (pendingSaveRef.current) {
+        pendingSaveRef.current = false;
+        // 등록 시점이 아닌 완료 시점의 최신 상태로 저장
+        const { lastSyncedPosition, lastSyncedVillageId } = useMovementStore.getState();
+        void trySave(userId, lastSyncedVillageId, lastSyncedPosition);
+      }
     }
   };
 

--- a/src/features/movement/hooks/useSavePlayerPosition.ts
+++ b/src/features/movement/hooks/useSavePlayerPosition.ts
@@ -1,0 +1,151 @@
+"use client";
+
+import { VillageId } from "@/entities/village";
+import { savePlayerPosition } from "@/features/movement/lib/playerPositionService";
+import { Position } from "@/features/movement/model/types";
+import { useMovementStore } from "@/features/movement/model/useMovementStore";
+import { supabase } from "@/shared/config/supabase.client";
+import { useUserInfo } from "@/shared/hooks/useUserInfo";
+
+import { useEffect, useRef } from "react";
+
+// 영속 저장 주기 (ms)
+const SAVE_INTERVAL_MS = 5000;
+
+interface SaveState {
+  position: Position;
+  villageId: VillageId;
+}
+
+/**
+ * 플레이어 위치를 필요한 시점에만 DB에 저장한다.
+ *
+ * 저장 시점 3가지
+ * 1. 5초 주기 저장 - 위치가 변경된 경우에만
+ * 2. 빌리지 이동 시 즉시 저장
+ * 3. 페이지 이탈(pagehide) 시 best-effort 저장 (keepalive fetch)
+ *
+ * @param enabled - 위치 복원이 완료된 후에만 활성화 (복원 전 기본 위치 저장 방지)
+ */
+export function useSavePlayerPosition(enabled: boolean) {
+  const { data: user } = useUserInfo();
+  // 마지막으로 DB에 저장한 상태를 추적해 불필요한 중복 저장을 방지한다
+  const lastSavedRef = useRef<SaveState | null>(null);
+  // 동시 저장 요청 방지 플래그
+  const isSavingRef = useRef(false);
+  // pagehide 시 동기적으로 접근해야 해서 ref에 캐싱
+  const accessTokenRef = useRef<string | null>(null);
+
+  // 인증 토큰을 ref에 캐싱 (pagehide keepalive fetch에서 사용)
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      accessTokenRef.current = data.session?.access_token ?? null;
+    });
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_, session) => {
+      accessTokenRef.current = session?.access_token ?? null;
+    });
+
+    return () => listener.subscription.unsubscribe();
+  }, []);
+
+  // 위치가 변경된 경우에만 저장하는 내부 함수
+  const trySave = async (userId: string, villageId: VillageId, position: Position) => {
+    if (isSavingRef.current) return;
+
+    const rx = Math.round(position.x);
+    const ry = Math.round(position.y);
+    const last = lastSavedRef.current;
+
+    // 마지막 저장 위치와 동일하면 저장 생략
+    if (last && last.villageId === villageId && last.position.x === rx && last.position.y === ry) {
+      return;
+    }
+
+    isSavingRef.current = true;
+    try {
+      await savePlayerPosition(userId, villageId, position);
+      lastSavedRef.current = { villageId, position: { x: rx, y: ry } };
+    } catch (err) {
+      // 저장 실패 시 다음 주기에서 재시도 (lastSavedRef를 갱신하지 않으므로 자동 재시도됨)
+      console.error("[useSavePlayerPosition] 저장 실패:", err);
+    } finally {
+      isSavingRef.current = false;
+    }
+  };
+
+  // 1. 5초 주기 저장 - 위치가 변경된 경우에만 실행
+  useEffect(() => {
+    if (!enabled || !user) return;
+
+    const interval = setInterval(() => {
+      const { lastSyncedPosition, lastSyncedVillageId } = useMovementStore.getState();
+      void trySave(user.id, lastSyncedVillageId, lastSyncedPosition);
+    }, SAVE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [enabled, user]);
+
+  // 2. 빌리지 이동 시 즉시 저장
+  useEffect(() => {
+    if (!enabled || !user) return;
+
+    return useMovementStore.subscribe(
+      (state) => state.lastSyncedVillageId,
+      (villageId) => {
+        const { lastSyncedPosition } = useMovementStore.getState();
+        void trySave(user.id, villageId, lastSyncedPosition);
+      },
+    );
+  }, [enabled, user]);
+
+  // 3. 페이지 이탈(새로고침/탭 닫기) 시 best-effort 저장
+  // keepalive fetch를 사용해 페이지가 언로드된 후에도 요청이 완료될 수 있도록 한다.
+  useEffect(() => {
+    if (!enabled || !user) return;
+
+    const handlePageHide = () => {
+      const { lastSyncedPosition, lastSyncedVillageId } = useMovementStore.getState();
+      const rx = Math.round(lastSyncedPosition.x);
+      const ry = Math.round(lastSyncedPosition.y);
+      const last = lastSavedRef.current;
+
+      // 이미 최신 상태가 저장되어 있으면 생략
+      if (
+        last &&
+        last.villageId === lastSyncedVillageId &&
+        last.position.x === rx &&
+        last.position.y === ry
+      ) {
+        return;
+      }
+
+      const token = accessTokenRef.current;
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      if (!token || !supabaseUrl || !supabaseAnonKey) return;
+
+      // Supabase 클라이언트 대신 fetch keepalive를 직접 사용
+      // pagehide 이후에도 브라우저가 요청을 완료할 수 있다
+      void fetch(`${supabaseUrl}/rest/v1/user_position`, {
+        method: "POST",
+        headers: {
+          apikey: supabaseAnonKey,
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Prefer: "resolution=merge-duplicates",
+        },
+        body: JSON.stringify({
+          user_id: user.id,
+          village_id: lastSyncedVillageId,
+          x: rx,
+          y: ry,
+        }),
+        keepalive: true,
+      });
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    return () => window.removeEventListener("pagehide", handlePageHide);
+  }, [enabled, user]);
+}

--- a/src/features/movement/hooks/useSavePlayerPosition.ts
+++ b/src/features/movement/hooks/useSavePlayerPosition.ts
@@ -117,15 +117,15 @@ export function useSavePlayerPosition(enabled: boolean) {
     if (!enabled || !user) return;
 
     const handlePageHide = () => {
-      const { lastSyncedPosition, lastSyncedVillageId } = useMovementStore.getState();
-      const rx = Math.round(lastSyncedPosition.x);
-      const ry = Math.round(lastSyncedPosition.y);
+      const { position, villageId } = useMovementStore.getState();
+      const rx = Math.round(position.x);
+      const ry = Math.round(position.y);
       const last = lastSavedRef.current;
 
       // 이미 최신 상태가 저장되어 있으면 생략
       if (
         last &&
-        last.villageId === lastSyncedVillageId &&
+        last.villageId === villageId &&
         last.position.x === rx &&
         last.position.y === ry
       ) {
@@ -149,7 +149,7 @@ export function useSavePlayerPosition(enabled: boolean) {
         },
         body: JSON.stringify({
           user_id: user.id,
-          village_id: lastSyncedVillageId,
+          village_id: villageId,
           x: rx,
           y: ry,
         }),

--- a/src/features/movement/hooks/useSavePlayerPosition.ts
+++ b/src/features/movement/hooks/useSavePlayerPosition.ts
@@ -139,7 +139,7 @@ export function useSavePlayerPosition(enabled: boolean) {
 
       // Supabase 클라이언트 대신 fetch keepalive를 직접 사용
       // pagehide 이후에도 브라우저가 요청을 완료할 수 있다
-      void fetch(`${supabaseUrl}/rest/v1/user_position`, {
+      void fetch(`${supabaseUrl}/rest/v1/user_position?on_conflict=user_id`, {
         method: "POST",
         headers: {
           apikey: supabaseAnonKey,

--- a/src/features/movement/lib/playerPositionService.ts
+++ b/src/features/movement/lib/playerPositionService.ts
@@ -1,0 +1,51 @@
+import { VillageId } from "@/entities/village";
+import { Position } from "@/features/movement/model/types";
+import { supabase } from "@/shared/config/supabase.client";
+
+export interface SavedPlayerPosition {
+  village_id: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * user_position 테이블에서 해당 유저의 마지막 저장 위치를 조회한다.
+ * 저장된 위치가 없으면 null을 반환한다.
+ */
+export const fetchPlayerPosition = async (userId: string): Promise<SavedPlayerPosition | null> => {
+  const { data, error } = await supabase
+    .from("user_position")
+    .select("village_id, x, y")
+    .eq("user_id", userId)
+    .single();
+
+  if (error) {
+    // PGRST116: 행이 없는 경우 (신규 유저)
+    if (error.code === "PGRST116") return null;
+    throw error;
+  }
+
+  return data;
+};
+
+/**
+ * user_position 테이블에 현재 위치를 upsert한다.
+ * 유저당 1행을 유지하며, 중복 시 덮어쓴다(last write wins).
+ */
+export const savePlayerPosition = async (
+  userId: string,
+  villageId: VillageId,
+  position: Position,
+) => {
+  const { error } = await supabase.from("user_position").upsert(
+    {
+      user_id: userId,
+      village_id: villageId,
+      x: Math.round(position.x),
+      y: Math.round(position.y),
+    },
+    { onConflict: "user_id" },
+  );
+
+  if (error) throw error;
+};

--- a/src/features/movement/lib/validateMovement.ts
+++ b/src/features/movement/lib/validateMovement.ts
@@ -7,6 +7,17 @@ import {
 } from "@/features/movement/model/types";
 
 /**
+ * DB에서 불러온 저장 위치가 현재 맵 기준으로 유효한지 검증한다.
+ * villageId가 존재하고 x/y가 해당 village 경계 안에 있어야 유효하다.
+ */
+export const isValidSavedPosition = (villageId: string, position: Position): boolean => {
+  const config = VILLAGES[villageId as VillageId];
+  if (!config) return false;
+  const { x1, y1, x2, y2 } = config.boundary;
+  return position.x >= x1 && position.x <= x2 && position.y >= y1 && position.y <= y2;
+};
+
+/**
  * 플레이어의 좌표가 마을을 벗어나지 않도록 경계값 내로 제한(Clamping)합니다.
  */
 const clampPositionToVillage = (position: Position, villageId: VillageId): Position => {

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -62,16 +62,16 @@ export const useMovementStore = create<MovementStore>()(
       setNickname: (nickname) => set({ nickname }),
       setPosition: (position) => set({ position, lastSyncedPosition: position }),
       setVillage: (villageId) => set({ villageId, lastSyncedVillageId: villageId }),
-      // 접속 시 DB에서 불러온 마지막 저장 위치를 초기값으로 설정한다.
-      // warp와 달리 findSafeSpawnPosition을 거치지 않고 위치를 그대로 적용한다.
-      initializePosition: (position, villageId) =>
+      initializePosition: (position, villageId) => {
+        const safePos = findSafeSpawnPosition(position, get().remotePlayers, villageId);
         set({
-          position,
+          position: safePos,
           villageId,
-          lastSyncedPosition: position,
+          lastSyncedPosition: safePos,
           lastSyncedVillageId: villageId,
           pendingDelta: { x: 0, y: 0 },
-        }),
+        });
+      },
 
       updateRemotePlayer: (player) =>
         set((state) => ({

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -16,6 +16,7 @@ interface MovementStore extends MovementState {
   setNickname: (nickname: string) => void;
   setPosition: (position: Position) => void;
   setVillage: (villageId: VillageId) => void;
+  initializePosition: (position: Position, villageId: VillageId) => void;
   warp: (position: Position, villageId: VillageId) => void;
   updatePosition: (delta: Position) => void;
   updateRemotePlayer: (player: RemotePlayer) => void;
@@ -61,6 +62,16 @@ export const useMovementStore = create<MovementStore>()(
       setNickname: (nickname) => set({ nickname }),
       setPosition: (position) => set({ position, lastSyncedPosition: position }),
       setVillage: (villageId) => set({ villageId, lastSyncedVillageId: villageId }),
+      // 접속 시 DB에서 불러온 마지막 저장 위치를 초기값으로 설정한다.
+      // warp와 달리 findSafeSpawnPosition을 거치지 않고 위치를 그대로 적용한다.
+      initializePosition: (position, villageId) =>
+        set({
+          position,
+          villageId,
+          lastSyncedPosition: position,
+          lastSyncedVillageId: villageId,
+          pendingDelta: { x: 0, y: 0 },
+        }),
 
       updateRemotePlayer: (player) =>
         set((state) => ({

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -1,25 +1,33 @@
 "use client";
 
+import { useMovementSync } from "@/features/movement/hooks/useMovementSync";
+import { useRestorePlayerPosition } from "@/features/movement/hooks/useRestorePlayerPosition";
+import { useSavePlayerPosition } from "@/features/movement/hooks/useSavePlayerPosition";
 import { TownScene } from "@/features/movement/lib/TownScene";
 import { GAME_CONFIG } from "@/features/movement/model/config";
+import { MovementOverlay } from "@/features/movement/ui/MovementOverlay";
 import * as Phaser from "phaser";
 
 import React, { useEffect, useRef } from "react";
 
-import { useMovementSync } from "../hooks/useMovementSync";
-import { MovementOverlay } from "./MovementOverlay";
-
 /**
- * 마을 엔진 컨테이너: Phaser 게임 인스턴스를 생성하고 관리합니다.
+ * 마을 엔진 컨테이너: Phaser 게임 인스턴스를 생성하고 관리한다.
+ *
+ * 마지막 저장 위치 조회(isReady)가 완료되기 전까지 Phaser 마운트를 보류해
+ * 기본 위치에 잠깐 나타났다가 저장 위치로 이동하는 텔레포트 현상을 방지한다.
  */
 export const TownEngine = () => {
   const gameContainerRef = useRef<HTMLDivElement>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
 
+  // 위치 복원 완료 여부 - true가 되기 전까지 엔진 마운트 보류
+  const { isReady } = useRestorePlayerPosition();
+  // 위치 복원 완료 후에만 저장 활성화 (복원 전 기본 위치가 저장되는 것을 방지)
+  useSavePlayerPosition(isReady);
   useMovementSync();
 
   useEffect(() => {
-    if (!gameContainerRef.current || gameRef.current) return;
+    if (!isReady || !gameContainerRef.current || gameRef.current) return;
 
     const config: Phaser.Types.Core.GameConfig = {
       type: Phaser.AUTO,
@@ -38,7 +46,7 @@ export const TownEngine = () => {
         gameRef.current = null;
       }
     };
-  }, []);
+  }, [isReady]);
 
   return (
     <div className="relative w-full h-full flex items-center justify-center bg-black overflow-hidden rounded-lg shadow-2xl border-4 border-gray-800">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

플레이어가 게임을 종료하거나 새로고침 후 재접속했을 때 마지막으로 이동한 위치로 복원되는 기능을 구현했습니다.

- `playerPositionService.ts`: 위치 데이터를 서버/스토리지에 저장·불러오는 서비스 레이어 추가
- `useSavePlayerPosition.ts`: 이동 시 위치를 주기적으로 저장하는 훅 추가
- `useRestorePlayerPosition.ts`: 입장 시 마지막 저장 위치를 불러와 스폰 좌표에 적용하는 훅 추가
- `useMovementStore.ts`: 저장된 위치 상태 필드 추가
- `validateMovement.ts`: 복원된 좌표의 유효성 검증 로직 보완
- `TownEngine.tsx`: 위치 복원 훅 연결


## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)
https://github.com/user-attachments/assets/2e589783-3ca0-4627-a98b-6def6c191b89


## 💬 추가 전달사항

- **주의깊게 봐주길 원하는 부분:** `useRestorePlayerPosition` 에서 저장된 좌표가 현재 빌리지 범위를 벗어났을 때 폴백 처리 로직을 검토부탁드립니다.
- **함께 고민하고 싶은 부분:** 위치 저장 주기(디바운스 간격) 및 저장 시점(이동 완료 vs 실시간) 전략이 적절한지 한번 봐주세요....

