### PR TITLE
[refactor] TownVoiceClient 콜백 안정화 및 음성 로직 레이어 분리 #108

### DIFF
--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -3,12 +3,11 @@
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { useTownPanelToggleStore } from "@/features/panelToggle";
 import { useTownPresence } from "@/features/presence";
-import { useTownPresenceStore } from "@/features/presence/model/useTownPresenceStore";
-import { TownVoiceClient } from "@/features/voice-chat";
 import { useUserInfo } from "@/shared/hooks";
 import { useUserStore } from "@/shared/store/useUserStore";
 import { ChatPanel } from "@/widgets/chatPanel";
 import { TownToolbar } from "@/widgets/townToolbar";
+import { TownVoiceSection } from "@/widgets/townVoiceSection";
 import { UsersPanel } from "@/widgets/usersPanel";
 
 import { useEffect } from "react";
@@ -27,26 +26,19 @@ export default function TownPage() {
   const router = useRouter();
   const { data: user, isLoading } = useUserInfo();
   const userNickname = user?.user_metadata?.nickname;
-  const isSpeaker = userNickname === process.env.NEXT_PUBLIC_SPEAKER_NICKNAME;
-  const setVoiceConnected = useTownPresenceStore((state) => state.setVoiceConnected);
-  const setIsSpeaker = useTownPresenceStore((state) => state.setIsSpeaker);
-  const setAudioEnabled = useTownPresenceStore((state) => state.setAudioEnabled);
-  const setAudioController = useTownPresenceStore((state) => state.setAudioController);
-  const setListeningController = useTownPresenceStore((state) => state.setListeningController);
-  const setListeningEnabled = useTownPresenceStore((state) => state.setListeningEnabled);
-  const setAudioToggling = useTownPresenceStore((state) => state.setAudioToggling);
   const { setUserNickname } = useUserStore();
   const activePanel = useTownPanelToggleStore((state) => state.activePanel);
   const resetMovement = useMovementStore((state) => state.reset);
   useTownPresence();
 
-  // 페이지 언마운트 시 무브먼트 상태 초기화
+  /** 페이지 이탈 시 타운 이동 상태를 초기화해 이전 씬 데이터를 남기지 않는다. */
   useEffect(() => {
     return () => {
       resetMovement();
     };
   }, [resetMovement]);
 
+  /** 인증 사용자 닉네임을 클라이언트 store에 동기화한다. */
   useEffect(() => {
     if (userNickname) {
       setUserNickname(userNickname);
@@ -54,20 +46,10 @@ export default function TownPage() {
   }, [setUserNickname, userNickname]);
 
   useEffect(() => {
-    setIsSpeaker(isSpeaker);
-  }, [isSpeaker, setIsSpeaker]);
-
-  useEffect(() => {
     if (!isLoading && !userNickname) {
       router.push("/");
     }
   }, [isLoading, userNickname, router]);
-
-  const nicknameFallback = (
-    <div className="flex h-full items-center justify-center text-gray-500">
-      닉네임을 설정해주세요.
-    </div>
-  );
 
   if (isLoading && !userNickname) {
     return (
@@ -77,40 +59,29 @@ export default function TownPage() {
     );
   }
 
-  const renderPanel = () => {
-    if (activePanel === "users") {
-      return <UsersPanel />;
-    }
-
-    if (!userNickname) {
-      return nicknameFallback;
-    }
-
-    return <ChatPanel />;
-  };
+  const panelContent =
+    activePanel === "users" ? (
+      <UsersPanel />
+    ) : userNickname ? (
+      <ChatPanel />
+    ) : (
+      <div className="flex h-full items-center justify-center text-gray-500">
+        닉네임을 설정해주세요.
+      </div>
+    );
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <div className="flex min-h-0 flex-1">
-        <div className="flex-1 flex items-center justify-center p-4">
+        <div className="flex flex-1 items-center justify-center p-4">
           <TownEngine />
         </div>
-        <div className="flex h-full w-96 flex-col">{renderPanel()}</div>
+        <div className="flex h-full w-96 flex-col">{panelContent}</div>
       </div>
 
-      {user?.id && userNickname && (
-        <TownVoiceClient
-          userId={user.id}
-          nickname={userNickname}
-          isSpeaker={isSpeaker}
-          onConnectionChange={setVoiceConnected}
-          onAudioEnabledChange={setAudioEnabled}
-          onAudioControllerChange={setAudioController}
-          onAudioTogglingChange={setAudioToggling}
-          onListeningControllerChange={setListeningController}
-          onListeningEnabledChange={setListeningEnabled}
-        />
-      )}
+      {user?.id && userNickname ? (
+        <TownVoiceSection userId={user.id} userNickname={userNickname} />
+      ) : null}
       <TownToolbar />
     </div>
   );

--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -29,6 +29,7 @@ export default function TownPage() {
   const userNickname = user?.user_metadata?.nickname;
   const isSpeaker = userNickname === process.env.NEXT_PUBLIC_SPEAKER_NICKNAME;
   const setVoiceConnected = useTownPresenceStore((state) => state.setVoiceConnected);
+  const setIsSpeaker = useTownPresenceStore((state) => state.setIsSpeaker);
   const setAudioEnabled = useTownPresenceStore((state) => state.setAudioEnabled);
   const setAudioController = useTownPresenceStore((state) => state.setAudioController);
   const setListeningController = useTownPresenceStore((state) => state.setListeningController);
@@ -51,6 +52,10 @@ export default function TownPage() {
       setUserNickname(userNickname);
     }
   }, [setUserNickname, userNickname]);
+
+  useEffect(() => {
+    setIsSpeaker(isSpeaker);
+  }, [isSpeaker, setIsSpeaker]);
 
   useEffect(() => {
     if (!isLoading && !userNickname) {

--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -26,6 +26,7 @@ export default function TownPage() {
   const router = useRouter();
   const { data: user, isLoading } = useUserInfo();
   const userNickname = user?.user_metadata?.nickname;
+  const isSpeaker = userNickname === process.env.NEXT_PUBLIC_SPEAKER_NICKNAME;
   const { setUserNickname } = useUserStore();
   const activePanel = useTownPanelToggleStore((state) => state.activePanel);
   const resetMovement = useMovementStore((state) => state.reset);
@@ -80,9 +81,9 @@ export default function TownPage() {
       </div>
 
       {user?.id && userNickname ? (
-        <TownVoiceSection userId={user.id} userNickname={userNickname} />
+        <TownVoiceSection userId={user.id} userNickname={userNickname} isSpeaker={isSpeaker} />
       ) : null}
-      <TownToolbar />
+      <TownToolbar isSpeaker={isSpeaker} />
     </div>
   );
 }

--- a/src/features/presence/model/useTownPresenceStore.ts
+++ b/src/features/presence/model/useTownPresenceStore.ts
@@ -15,6 +15,8 @@ interface TownPresenceState {
   hasInitialized: boolean;
   /** 현재 유저의 음성 채널 연결 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
   voiceConnected: boolean;
+  /** 현재 유저가 speaker 역할인지 여부 */
+  isSpeaker: boolean;
   /** 현재 유저의 발표용 마이크 활성 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
   audioEnabled: boolean;
   /** 현재 유저가 사용자 패널에서 마이크 토글을 제어할 수 있는지 여부 */
@@ -41,6 +43,7 @@ interface TownPresenceState {
   setConnectionState: (isConnected: boolean) => void;
   /** 음성 연결 상태를 업데이트하고 presence track이 재전송되도록 한다. */
   setVoiceConnected: (voiceConnected: boolean) => void;
+  setIsSpeaker: (isSpeaker: boolean) => void;
   /** 발표용 마이크 활성 상태를 업데이트하고 presence track이 재전송되도록 한다. */
   setAudioEnabled: (audioEnabled: boolean) => void;
   /** 사용자 패널에서 사용할 마이크 토글 제어기를 등록한다. */
@@ -69,6 +72,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   previousUserIds: new Set(),
   hasInitialized: true,
   voiceConnected: false,
+  isSpeaker: false,
   audioEnabled: false,
   canToggleAudio: false,
   toggleLocalAudio: null,
@@ -136,6 +140,8 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
 
   setVoiceConnected: (voiceConnected) => set({ voiceConnected }),
 
+  setIsSpeaker: (isSpeaker) => set({ isSpeaker }),
+
   /**
    * 발표용 마이크 활성 상태를 업데이트하고 presence track이 재전송되도록 한다.
    */
@@ -175,6 +181,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
       previousUserIds: new Set(),
       hasInitialized: true,
       voiceConnected: false,
+      isSpeaker: false,
       audioEnabled: false,
       canToggleAudio: false,
       toggleLocalAudio: null,

--- a/src/features/presence/model/useTownPresenceStore.ts
+++ b/src/features/presence/model/useTownPresenceStore.ts
@@ -78,11 +78,15 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   toggleLocalListening: null,
 
   setParticipants: (participants, currentUserNickname, currentUserId) => {
-    const sortedParticipants = [...participants].sort((a, b) =>
+    const state = get();
+    const previousMe = state.participants.find((p) => p.userId === currentUserId);
+    const hasCurrentUser = participants.some((p) => p.userId === currentUserId);
+    const stableParticipants =
+      previousMe && !hasCurrentUser ? [...participants, previousMe] : participants;
+    const sortedParticipants = [...stableParticipants].sort((a, b) =>
       a.nickname.localeCompare(b.nickname, "ko"),
     );
     const groupedParticipants = groupParticipantsByVillage(sortedParticipants);
-    const state = get();
     const currentUserIds = sortedParticipants.map((p) => p.userId);
     const currentUserIdSet = new Set(currentUserIds);
 

--- a/src/features/presence/model/useTownPresenceStore.ts
+++ b/src/features/presence/model/useTownPresenceStore.ts
@@ -15,11 +15,9 @@ interface TownPresenceState {
   hasInitialized: boolean;
   /** 현재 유저의 음성 채널 연결 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
   voiceConnected: boolean;
-  /** 현재 유저가 speaker 역할인지 여부 */
-  isSpeaker: boolean;
   /** 현재 유저의 발표용 마이크 활성 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
   audioEnabled: boolean;
-  /** 현재 유저가 사용자 패널에서 마이크 토글을 제어할 수 있는지 여부 */
+  /** 현재 유저가 툴바 음성 제어 UI에서 마이크 토글을 제어할 수 있는지 여부 */
   canToggleAudio: boolean;
   /** 현재 유저의 마이크 토글을 수행하는 로컬 제어 함수 */
   toggleLocalAudio: (() => Promise<void>) | null;
@@ -28,7 +26,7 @@ interface TownPresenceState {
    * true인 동안 버튼을 disabled 처리해 중복 클릭을 막는다.
    */
   isAudioToggling: boolean;
-  /** 현재 유저가 사용자 패널에서 청취 토글을 제어할 수 있는지 여부 */
+  /** 현재 유저가 툴바 음성 제어 UI에서 청취 토글을 제어할 수 있는지 여부 */
   canToggleListening: boolean;
   /** 현재 유저의 실제 청취 on/off 상태 */
   listeningEnabled: boolean;
@@ -43,17 +41,16 @@ interface TownPresenceState {
   setConnectionState: (isConnected: boolean) => void;
   /** 음성 연결 상태를 업데이트하고 presence track이 재전송되도록 한다. */
   setVoiceConnected: (voiceConnected: boolean) => void;
-  setIsSpeaker: (isSpeaker: boolean) => void;
   /** 발표용 마이크 활성 상태를 업데이트하고 presence track이 재전송되도록 한다. */
   setAudioEnabled: (audioEnabled: boolean) => void;
-  /** 사용자 패널에서 사용할 마이크 토글 제어기를 등록한다. */
+  /** 툴바 음성 제어 UI에서 사용할 마이크 토글 제어기를 등록한다. */
   setAudioController: (
     canToggleAudio: boolean,
     toggleLocalAudio: (() => Promise<void>) | null,
   ) => void;
   /** 마이크 토글 SDK 호출 진행 상태를 업데이트한다. */
   setAudioToggling: (isAudioToggling: boolean) => void;
-  /** 사용자 패널에서 사용할 청취 토글 제어기를 등록한다. */
+  /** 툴바 음성 제어 UI에서 사용할 청취 토글 제어기를 등록한다. */
   setListeningController: (
     canToggleListening: boolean,
     toggleLocalListening: (() => Promise<void>) | null,
@@ -72,7 +69,6 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   previousUserIds: new Set(),
   hasInitialized: true,
   voiceConnected: false,
-  isSpeaker: false,
   audioEnabled: false,
   canToggleAudio: false,
   toggleLocalAudio: null,
@@ -86,7 +82,6 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
       a.nickname.localeCompare(b.nickname, "ko"),
     );
     const groupedParticipants = groupParticipantsByVillage(sortedParticipants);
-
     const state = get();
     const currentUserIds = sortedParticipants.map((p) => p.userId);
     const currentUserIdSet = new Set(currentUserIds);
@@ -140,15 +135,13 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
 
   setVoiceConnected: (voiceConnected) => set({ voiceConnected }),
 
-  setIsSpeaker: (isSpeaker) => set({ isSpeaker }),
-
   /**
    * 발표용 마이크 활성 상태를 업데이트하고 presence track이 재전송되도록 한다.
    */
   setAudioEnabled: (audioEnabled) => set({ audioEnabled }),
 
   /**
-   * 사용자 패널에서 사용할 마이크 토글 제어기를 등록한다.
+   * 툴바 음성 제어 UI에서 사용할 마이크 토글 제어기를 등록한다.
    */
   setAudioController: (canToggleAudio, toggleLocalAudio) =>
     set({
@@ -159,7 +152,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   setAudioToggling: (isAudioToggling) => set({ isAudioToggling }),
 
   /**
-   * 사용자 패널에서 사용할 청취 토글 제어기를 등록한다.
+   * 툴바 음성 제어 UI에서 사용할 청취 토글 제어기를 등록한다.
    */
   setListeningController: (canToggleListening, toggleLocalListening) =>
     set({
@@ -181,7 +174,6 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
       previousUserIds: new Set(),
       hasInitialized: true,
       voiceConnected: false,
-      isSpeaker: false,
       audioEnabled: false,
       canToggleAudio: false,
       toggleLocalAudio: null,

--- a/src/features/presence/ui/PresenceToolbarButton.tsx
+++ b/src/features/presence/ui/PresenceToolbarButton.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Button } from "@/shared/ui/button";
-import { Mic, MicOff, Users, Volume2, VolumeX } from "lucide-react";
-
 import { useTownPresenceStore } from "../model/useTownPresenceStore";
+import { UsersPanelToggleButton } from "./UsersPanelToggleButton";
+import { VoiceControlGroup } from "./VoiceControlGroup";
 
 interface PresenceToolbarButtonProps {
   onToggle?: () => void;
@@ -16,6 +15,8 @@ export const PresenceToolbarButton = ({
 }: PresenceToolbarButtonProps) => {
   const participantCount = useTownPresenceStore((state) => state.participants.length);
   const isConnected = useTownPresenceStore((state) => state.isConnected);
+  const voiceConnected = useTownPresenceStore((state) => state.voiceConnected);
+  const isSpeaker = useTownPresenceStore((state) => state.isSpeaker);
 
   const canToggleAudio = useTownPresenceStore((state) => state.canToggleAudio);
   const toggleLocalAudio = useTownPresenceStore((state) => state.toggleLocalAudio);
@@ -26,94 +27,25 @@ export const PresenceToolbarButton = ({
   const toggleLocalListening = useTownPresenceStore((state) => state.toggleLocalListening);
   const listeningEnabled = useTownPresenceStore((state) => state.listeningEnabled);
 
-  const toggleLabel = isUsersPanel ? "채팅 패널로 보기" : "사용자 패널로 보기";
-  const toggleText = isUsersPanel ? "채팅" : "사용자";
-  const connectionIndicatorClass = `h-2 w-2 rounded-full ${
-    isConnected ? "bg-emerald-500" : "bg-red-500"
-  }`;
-  const connectionIndicatorText = isConnected ? "연결됨" : "연결 끊김";
-
-  const handleToggleAudio = () => {
-    if (!canToggleAudio || !toggleLocalAudio || isAudioToggling) return;
-    void toggleLocalAudio();
-  };
-
-  const handleToggleListening = () => {
-    if (!canToggleListening || !toggleLocalListening) return;
-    void toggleLocalListening();
-  };
-
   return (
-    <div className="flex items-center justify-end gap-2">
-      {canToggleAudio ? (
-        <Button
-          type="button"
-          variant={audioEnabled ? "default" : "outline"}
-          size="sm"
-          aria-label={audioEnabled ? "마이크 끄기" : "마이크 켜기"}
-          aria-pressed={audioEnabled}
-          disabled={!toggleLocalAudio || isAudioToggling}
-          onClick={handleToggleAudio}
-          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
-        >
-          {audioEnabled ? (
-            <Mic className="h-4 w-4" aria-hidden />
-          ) : (
-            <MicOff className="h-4 w-4" aria-hidden />
-          )}
-          <span>{audioEnabled ? "방송 중" : "마이크 켜기"}</span>
-        </Button>
-      ) : null}
-
-      {canToggleListening ? (
-        <Button
-          type="button"
-          variant={listeningEnabled ? "default" : "outline"}
-          size="sm"
-          aria-label={listeningEnabled ? "청취 중지" : "청취 시작"}
-          aria-pressed={listeningEnabled}
-          disabled={!toggleLocalListening}
-          onClick={handleToggleListening}
-          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
-        >
-          {listeningEnabled ? (
-            <Volume2 className="h-4 w-4" aria-hidden />
-          ) : (
-            <VolumeX className="h-4 w-4" aria-hidden />
-          )}
-          <span>{listeningEnabled ? "청취 중" : "청취 시작"}</span>
-        </Button>
-      ) : null}
-
-      <Button
-        type="button"
-        variant={isUsersPanel ? "default" : "outline"}
-        size="sm"
-        aria-pressed={isUsersPanel}
-        aria-label={toggleLabel}
-        onClick={onToggle}
-        className={`flex h-10 min-w-[145px] items-center justify-between gap-2 rounded-full px-4 text-sm font-medium transition-colors shadow-sm ${
-          isUsersPanel
-            ? "border border-gray-900 bg-gray-900 text-white"
-            : "border bg-white text-gray-700"
-        }`}
-      >
-        <div className="flex items-center gap-2">
-          <Users className="h-4 w-4" aria-hidden />
-          <span>{participantCount}</span>
-          <span className="hidden sm:inline">{toggleText}</span>
-        </div>
-
-        <span
-          className={`flex items-center gap-1 text-[11px] font-normal ${
-            isUsersPanel ? "text-gray-300" : "text-gray-500"
-          }`}
-          aria-live="polite"
-        >
-          <span className={connectionIndicatorClass} aria-hidden />
-          <span>{connectionIndicatorText}</span>
-        </span>
-      </Button>
+    <div className="flex items-center w-full justify-end gap-2">
+      <VoiceControlGroup
+        isSpeaker={isSpeaker}
+        voiceConnected={voiceConnected}
+        canToggleAudio={canToggleAudio}
+        toggleLocalAudio={toggleLocalAudio}
+        audioEnabled={audioEnabled}
+        isAudioToggling={isAudioToggling}
+        canToggleListening={canToggleListening}
+        toggleLocalListening={toggleLocalListening}
+        listeningEnabled={listeningEnabled}
+      />
+      <UsersPanelToggleButton
+        participantCount={participantCount}
+        isConnected={isConnected}
+        isUsersPanel={isUsersPanel}
+        onToggle={onToggle}
+      />
     </div>
   );
 };

--- a/src/features/presence/ui/PresenceToolbarButton.tsx
+++ b/src/features/presence/ui/PresenceToolbarButton.tsx
@@ -5,18 +5,19 @@ import { UsersPanelToggleButton } from "./UsersPanelToggleButton";
 import { VoiceControlGroup } from "./VoiceControlGroup";
 
 interface PresenceToolbarButtonProps {
+  isSpeaker: boolean;
   onToggle?: () => void;
   isUsersPanel?: boolean;
 }
 
 export const PresenceToolbarButton = ({
+  isSpeaker,
   onToggle,
   isUsersPanel = false,
 }: PresenceToolbarButtonProps) => {
   const participantCount = useTownPresenceStore((state) => state.participants.length);
   const isConnected = useTownPresenceStore((state) => state.isConnected);
   const voiceConnected = useTownPresenceStore((state) => state.voiceConnected);
-  const isSpeaker = useTownPresenceStore((state) => state.isSpeaker);
 
   const canToggleAudio = useTownPresenceStore((state) => state.canToggleAudio);
   const toggleLocalAudio = useTownPresenceStore((state) => state.toggleLocalAudio);

--- a/src/features/presence/ui/UsersPanelToggleButton.tsx
+++ b/src/features/presence/ui/UsersPanelToggleButton.tsx
@@ -16,6 +16,7 @@ export function UsersPanelToggleButton({
   isUsersPanel = false,
   onToggle,
 }: UsersPanelToggleButtonProps) {
+  /** 기존 사용자 패널 토글 버튼과 텍스트 채널 연결 상태 표시는 별도 책임으로 유지한다. */
   const toggleLabel = isUsersPanel ? "채팅 패널로 보기" : "사용자 패널로 보기";
   const toggleText = isUsersPanel ? "채팅" : "사용자";
 

--- a/src/features/presence/ui/UsersPanelToggleButton.tsx
+++ b/src/features/presence/ui/UsersPanelToggleButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@/shared/ui/button";
+import { Users } from "lucide-react";
+
+interface UsersPanelToggleButtonProps {
+  participantCount: number;
+  isConnected: boolean;
+  isUsersPanel?: boolean;
+  onToggle?: () => void;
+}
+
+export function UsersPanelToggleButton({
+  participantCount,
+  isConnected,
+  isUsersPanel = false,
+  onToggle,
+}: UsersPanelToggleButtonProps) {
+  const toggleLabel = isUsersPanel ? "채팅 패널로 보기" : "사용자 패널로 보기";
+  const toggleText = isUsersPanel ? "채팅" : "사용자";
+
+  return (
+    <Button
+      type="button"
+      variant={isUsersPanel ? "default" : "outline"}
+      size="sm"
+      aria-pressed={isUsersPanel}
+      aria-label={toggleLabel}
+      onClick={onToggle}
+      className={`flex h-10 min-w-[145px] items-center justify-between gap-2 rounded-full px-4 text-sm font-medium transition-colors shadow-sm ${
+        isUsersPanel
+          ? "border border-gray-900 bg-gray-900 text-white"
+          : "border bg-white text-gray-700"
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <Users className="h-4 w-4" aria-hidden />
+        <span>{participantCount}</span>
+        <span className="hidden sm:inline">{toggleText}</span>
+      </div>
+      <span
+        className={`flex items-center gap-1 text-[11px] font-normal ${
+          isUsersPanel ? "text-gray-300" : "text-gray-500"
+        }`}
+        aria-live="polite"
+      >
+        <span
+          className={`h-2 w-2 rounded-full ${isConnected ? "bg-emerald-500" : "bg-red-500"}`}
+          aria-hidden
+        />
+        <span>{isConnected ? "연결됨" : "연결 끊김"}</span>
+      </span>
+    </Button>
+  );
+}

--- a/src/features/presence/ui/VoiceControlGroup.tsx
+++ b/src/features/presence/ui/VoiceControlGroup.tsx
@@ -26,6 +26,10 @@ export function VoiceControlGroup({
   toggleLocalListening,
   listeningEnabled,
 }: VoiceControlGroupProps) {
+  /**
+   * 음성 역할 상태와 실제 음성 제어 버튼을 한 묶음으로 렌더링한다.
+   * speaker와 listener가 같은 레이아웃 안에서 역할 텍스트만 달리 보여주도록 유지한다.
+   */
   const roleText = isSpeaker ? "방송자" : "청취자";
   const connectionIndicatorText = voiceConnected ? "연결됨" : "연결 중";
 

--- a/src/features/presence/ui/VoiceControlGroup.tsx
+++ b/src/features/presence/ui/VoiceControlGroup.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Button } from "@/shared/ui/button";
+import { Mic, MicOff, Volume2, VolumeX } from "lucide-react";
+
+interface VoiceControlGroupProps {
+  isSpeaker: boolean;
+  voiceConnected: boolean;
+  canToggleAudio: boolean;
+  toggleLocalAudio: (() => Promise<void>) | null;
+  audioEnabled: boolean;
+  isAudioToggling: boolean;
+  canToggleListening: boolean;
+  toggleLocalListening: (() => Promise<void>) | null;
+  listeningEnabled: boolean;
+}
+
+export function VoiceControlGroup({
+  isSpeaker,
+  voiceConnected,
+  canToggleAudio,
+  toggleLocalAudio,
+  audioEnabled,
+  isAudioToggling,
+  canToggleListening,
+  toggleLocalListening,
+  listeningEnabled,
+}: VoiceControlGroupProps) {
+  const roleText = isSpeaker ? "방송자" : "청취자";
+  const connectionIndicatorText = voiceConnected ? "연결됨" : "연결 중";
+
+  const handleToggleAudio = () => {
+    if (!canToggleAudio || !toggleLocalAudio || isAudioToggling) return;
+    void toggleLocalAudio();
+  };
+
+  const handleToggleListening = () => {
+    if (!canToggleListening || !toggleLocalListening) return;
+    void toggleLocalListening();
+  };
+
+  if (!canToggleAudio && !canToggleListening) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <div className="flex items-center gap-2 bg-white px-3 py-2">
+        <span className="text-sm font-medium text-gray-900">현재 역할: {roleText}</span>
+        <span className="h-3 w-px bg-gray-200" aria-hidden />
+        <span
+          className="flex items-center gap-1 text-xs font-normal text-gray-500"
+          aria-live="polite"
+        >
+          <span>음성 연결 상태: {connectionIndicatorText}</span>
+        </span>
+      </div>
+
+      {canToggleAudio ? (
+        <Button
+          type="button"
+          variant={audioEnabled ? "default" : "outline"}
+          size="sm"
+          aria-label={audioEnabled ? "마이크 끄기" : "마이크 켜기"}
+          aria-pressed={audioEnabled}
+          disabled={!toggleLocalAudio || isAudioToggling}
+          onClick={handleToggleAudio}
+          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
+        >
+          {audioEnabled ? (
+            <Mic className="h-4 w-4" aria-hidden />
+          ) : (
+            <MicOff className="h-4 w-4" aria-hidden />
+          )}
+          <span>{audioEnabled ? "방송 중" : "마이크 켜기"}</span>
+        </Button>
+      ) : null}
+
+      {canToggleListening ? (
+        <Button
+          type="button"
+          variant={listeningEnabled ? "default" : "outline"}
+          size="sm"
+          aria-label={listeningEnabled ? "청취 중지" : "청취 시작"}
+          aria-pressed={listeningEnabled}
+          disabled={!toggleLocalListening}
+          onClick={handleToggleListening}
+          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
+        >
+          {listeningEnabled ? (
+            <Volume2 className="h-4 w-4" aria-hidden />
+          ) : (
+            <VolumeX className="h-4 w-4" aria-hidden />
+          )}
+          <span>{listeningEnabled ? "청취 중" : "청취 시작"}</span>
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/presence/ui/VoiceControlGroup.tsx
+++ b/src/features/presence/ui/VoiceControlGroup.tsx
@@ -32,20 +32,18 @@ export function VoiceControlGroup({
    */
   const roleText = isSpeaker ? "방송자" : "청취자";
   const connectionIndicatorText = voiceConnected ? "연결됨" : "연결 중";
+  const isAudioButtonDisabled = !canToggleAudio || !toggleLocalAudio || isAudioToggling;
+  const isListeningButtonDisabled = !canToggleListening || !toggleLocalListening;
 
   const handleToggleAudio = () => {
-    if (!canToggleAudio || !toggleLocalAudio || isAudioToggling) return;
+    if (isAudioButtonDisabled) return;
     void toggleLocalAudio();
   };
 
   const handleToggleListening = () => {
-    if (!canToggleListening || !toggleLocalListening) return;
+    if (isListeningButtonDisabled) return;
     void toggleLocalListening();
   };
-
-  if (!canToggleAudio && !canToggleListening) {
-    return null;
-  }
 
   return (
     <div className="flex items-center gap-2 w-full">
@@ -60,16 +58,16 @@ export function VoiceControlGroup({
         </span>
       </div>
 
-      {canToggleAudio ? (
+      {isSpeaker ? (
         <Button
           type="button"
           variant={audioEnabled ? "default" : "outline"}
           size="sm"
           aria-label={audioEnabled ? "마이크 끄기" : "마이크 켜기"}
           aria-pressed={audioEnabled}
-          disabled={!toggleLocalAudio || isAudioToggling}
+          disabled={isAudioButtonDisabled}
           onClick={handleToggleAudio}
-          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
+          className="flex h-10 min-w-[120px] cursor-pointer items-center gap-2 rounded-full px-4 shadow-sm disabled:pointer-events-auto disabled:cursor-not-allowed"
         >
           {audioEnabled ? (
             <Mic className="h-4 w-4" aria-hidden />
@@ -78,18 +76,16 @@ export function VoiceControlGroup({
           )}
           <span>{audioEnabled ? "방송 중" : "마이크 켜기"}</span>
         </Button>
-      ) : null}
-
-      {canToggleListening ? (
+      ) : (
         <Button
           type="button"
           variant={listeningEnabled ? "default" : "outline"}
           size="sm"
           aria-label={listeningEnabled ? "청취 중지" : "청취 시작"}
           aria-pressed={listeningEnabled}
-          disabled={!toggleLocalListening}
+          disabled={isListeningButtonDisabled}
           onClick={handleToggleListening}
-          className="flex h-10 min-w-[120px] items-center gap-2 rounded-full px-4 shadow-sm"
+          className="flex h-10 min-w-[120px] cursor-pointer items-center gap-2 rounded-full px-4 shadow-sm disabled:pointer-events-auto disabled:cursor-not-allowed"
         >
           {listeningEnabled ? (
             <Volume2 className="h-4 w-4" aria-hidden />
@@ -98,7 +94,7 @@ export function VoiceControlGroup({
           )}
           <span>{listeningEnabled ? "청취 중" : "청취 시작"}</span>
         </Button>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/src/features/voice-chat/hooks/useTownVoiceCallbacks.ts
+++ b/src/features/voice-chat/hooks/useTownVoiceCallbacks.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/** TownVoiceClient가 외부 UI 상태와 제어 함수를 동기화하기 위해 호출하는 콜백 모음 */
+export interface TownVoiceCallbacks {
+  /**
+   * 음성 연결 상태가 변경될 때 호출된다.
+   * connected가 true이면 연결 완료, false이면 연결 실패 또는 언마운트를 의미한다.
+   */
+  onConnectionChange?: (connected: boolean) => void;
+  /** 발표자의 마이크 활성 상태가 변경될 때 호출된다. */
+  onAudioEnabledChange?: (enabled: boolean) => void;
+  /** 툴바 음성 제어 UI에서 사용할 마이크 토글 제어기가 준비될 때 호출된다. */
+  onAudioControllerChange?: (
+    canToggleAudio: boolean,
+    toggleAudio: (() => Promise<void>) | null,
+  ) => void;
+  /** 툴바 음성 제어 UI에서 사용할 청취 토글 제어기가 준비될 때 호출된다. */
+  onListeningControllerChange?: (
+    canToggleListening: boolean,
+    toggleListening: (() => Promise<void>) | null,
+  ) => void;
+  /** 청취 on/off 상태가 변경될 때 호출된다. */
+  onListeningEnabledChange?: (enabled: boolean) => void;
+  /**
+   * 마이크 토글 SDK 호출의 진행 상태가 변경될 때 호출된다.
+   * true이면 토글 중, false이면 완료 또는 에러 상태를 의미한다.
+   */
+  onAudioTogglingChange?: (isToggling: boolean) => void;
+}
+
+/**
+ * 비동기 음성 연결 흐름에서 최신 props 콜백을 안정적으로 호출하기 위한 notifier를 제공한다.
+ * 반환되는 notify 함수들은 stable identity를 유지해 연결 effect가 콜백 변경만으로 재실행되지 않도록 한다.
+ */
+export function useTownVoiceCallbacks({
+  onConnectionChange,
+  onAudioEnabledChange,
+  onAudioControllerChange,
+  onListeningControllerChange,
+  onListeningEnabledChange,
+  onAudioTogglingChange,
+}: TownVoiceCallbacks) {
+  /**
+   * 비동기 연결 흐름, SDK 이벤트 리스너, cleanup에서 최신 콜백을 읽기 위한 참조다.
+   * 메인 연결 effect가 콜백 identity 변경으로 다시 실행되지 않도록 한다.
+   */
+  const callbacksRef = useRef({
+    onConnectionChange,
+    onAudioEnabledChange,
+    onAudioControllerChange,
+    onListeningControllerChange,
+    onListeningEnabledChange,
+    onAudioTogglingChange,
+  });
+
+  /** 매 커밋 후 최신 콜백으로 ref를 갱신해 stale callback을 방지한다. */
+  useEffect(() => {
+    callbacksRef.current = {
+      onConnectionChange,
+      onAudioEnabledChange,
+      onAudioControllerChange,
+      onListeningControllerChange,
+      onListeningEnabledChange,
+      onAudioTogglingChange,
+    };
+  });
+
+  const notifyConnectionChange = useCallback((connected: boolean) => {
+    callbacksRef.current.onConnectionChange?.(connected);
+  }, []);
+
+  const notifyAudioEnabledChange = useCallback((enabled: boolean) => {
+    callbacksRef.current.onAudioEnabledChange?.(enabled);
+  }, []);
+
+  const notifyAudioControllerChange = useCallback(
+    (canToggleAudio: boolean, toggleAudio: (() => Promise<void>) | null) => {
+      callbacksRef.current.onAudioControllerChange?.(canToggleAudio, toggleAudio);
+    },
+    [],
+  );
+
+  const notifyListeningControllerChange = useCallback(
+    (canToggleListening: boolean, toggleListening: (() => Promise<void>) | null) => {
+      callbacksRef.current.onListeningControllerChange?.(canToggleListening, toggleListening);
+    },
+    [],
+  );
+
+  const notifyListeningEnabledChange = useCallback((enabled: boolean) => {
+    callbacksRef.current.onListeningEnabledChange?.(enabled);
+  }, []);
+
+  const notifyAudioTogglingChange = useCallback((isToggling: boolean) => {
+    callbacksRef.current.onAudioTogglingChange?.(isToggling);
+  }, []);
+
+  return {
+    notifyConnectionChange,
+    notifyAudioEnabledChange,
+    notifyAudioControllerChange,
+    notifyListeningControllerChange,
+    notifyListeningEnabledChange,
+    notifyAudioTogglingChange,
+  };
+}

--- a/src/features/voice-chat/ui/TownVoiceClient.tsx
+++ b/src/features/voice-chat/ui/TownVoiceClient.tsx
@@ -254,21 +254,11 @@ export function TownVoiceClient({
         await initializedMeeting.joinRoom();
         joinedRoom = true;
 
-        console.log("self.roomJoined", initializedMeeting.self.roomJoined);
-        console.log("self.audioEnabled(before)", initializedMeeting.self.audioEnabled);
-        console.log("mediaPermissions(before)", initializedMeeting.self.mediaPermissions);
-
         if (!isMounted) return;
 
         if (!canUseMic && initializedMeeting.self.audioEnabled) {
           await initializedMeeting.self.disableAudio();
         }
-
-        console.log("participants.joined", initializedMeeting.participants.joined);
-        console.log(
-          "participants.audioSubscribed",
-          initializedMeeting.participants.audioSubscribed,
-        );
 
         callbacksRef.current.onAudioControllerChange?.(
           canUseMic,
@@ -281,13 +271,9 @@ export function TownVoiceClient({
 
         if (canUseMic) {
           try {
-            console.log("mediaPermissions(before)", initializedMeeting.self.mediaPermissions);
             await initializedMeeting.self.enableAudio();
-            console.log("self.audioEnabled(after)", initializedMeeting.self.audioEnabled);
-            console.log("mediaPermissions(after)", initializedMeeting.self.mediaPermissions);
           } catch (audioError) {
             console.error("enableAudio error", audioError);
-            console.log("mediaPermissions(error)", initializedMeeting.self.mediaPermissions);
             if (isMounted) {
               setErrorMessage(
                 audioError instanceof Error

--- a/src/features/voice-chat/ui/TownVoiceClient.tsx
+++ b/src/features/voice-chat/ui/TownVoiceClient.tsx
@@ -10,10 +10,9 @@ import { RtkParticipantsAudio } from "@cloudflare/realtimekit-react-ui";
 
 // import { RtkMicToggle /*, RtkLivestreamPlayer */ } from "@cloudflare/
 // realtimekit-react-ui";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { requestVoiceToken } from "../api/requestVoiceToken";
-import type { RequestVoiceTokenResponse } from "../model/types";
 
 /** 타운 음성 방송에서 speaker 또는 listener로 연결하기 위한 props */
 export type TownVoiceClientProps = {
@@ -56,53 +55,27 @@ type ConnectionStatus =
   | "error";
 
 /**
- * 음성 채널 연결이 완료된 뒤 speaker/listener 역할에 맞는 UI를 렌더링한다.
+ * 음성 채널 연결이 완료된 뒤 오디오를 재생한다.
  *
- * speaker는 마이크 상태 안내를 보여주고,
- * listener는 speaker의 오디오를 재생한다.
+ * speaker는 항상 재생하고, listener는 isListeningEnabled일 때만 재생한다.
+ * RtkParticipantsAudio 렌더링을 위해 반드시 유지해야 한다.
  */
 function VoicePanel({
   isSpeaker,
   isListeningEnabled,
-  audioEnabled,
 }: {
   isSpeaker: boolean;
   isListeningEnabled: boolean;
-  audioEnabled: boolean;
 }) {
   const { meeting } = useRealtimeKitMeeting();
 
-  if (!meeting) {
-    return <p>음성 연결 정보를 불러오는 중입니다.</p>;
-  }
+  if (!meeting) return null;
 
   return (
-    <section className="rounded-xl border p-4">
-      <div className="mb-3">
-        <strong>{isSpeaker ? "방송자" : "청취자"}</strong>
-      </div>
-
-      {isSpeaker ? (
-        <div className="space-y-3">
-          <p>
-            {audioEnabled
-              ? "현재 타운 전체에 방송 중입니다."
-              : "사용자 패널의 마이크 버튼으로 타운 전체 방송을 시작할 수 있습니다."}
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          <p>
-            {isListeningEnabled
-              ? "현재 방송을 청취합니다."
-              : "사용자 패널의 헤드셋 버튼으로 청취를 시작할 수 있습니다."}
-          </p>
-          <p>isListeningEnabled: {String(isListeningEnabled)}</p>
-        </div>
-      )}
+    <>
       {/* 모든 역할에서 상대방 오디오를 재생한다. listener는 헤드셋 토글 상태를 따른다. */}
       {isSpeaker || isListeningEnabled ? <RtkParticipantsAudio meeting={meeting} /> : null}
-    </section>
+    </>
   );
 }
 
@@ -126,9 +99,7 @@ export function TownVoiceClient({
   const [client, initMeeting] = useRealtimeKitClient();
   const [status, setStatus] = useState<ConnectionStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [tokenResult, setTokenResult] = useState<RequestVoiceTokenResponse | null>(null);
   const [isListeningEnabled, setIsListeningEnabled] = useState(false);
-  const [localAudioEnabled, setLocalAudioEnabled] = useState(false);
 
   const meetingRef = useRef<typeof client | null>(null);
   const listeningEnabledRef = useRef(true);
@@ -136,7 +107,6 @@ export function TownVoiceClient({
    *  React 리렌더 전에 발생하는 중복 클릭을 state보다 먼저 차단한다. */
   const isAudioTogglingRef = useRef(false);
 
-  const roleLabel = useMemo(() => (isSpeaker ? "speaker" : "listener"), [isSpeaker]);
   const hasNickname = nickname.trim().length > 0;
   const canUseMic = hasNickname && isSpeaker;
 
@@ -153,7 +123,6 @@ export function TownVoiceClient({
       try {
         setStatus("requesting-token");
         setErrorMessage(null);
-        setLocalAudioEnabled(false);
         onAudioEnabledChange?.(false);
         onAudioTogglingChange?.(false);
         onAudioControllerChange?.(false, null);
@@ -171,7 +140,6 @@ export function TownVoiceClient({
 
         if (!isMounted) return;
 
-        setTokenResult(tokenResponse);
         setStatus("initializing");
 
         const mediaHandler = await initRTKMedia({
@@ -244,7 +212,6 @@ export function TownVoiceClient({
          * audioUpdate 이벤트 리스너로 등록되어 마이크 상태 변화를 감지한다.
          */
         const keepAudioDisabled = ({ audioEnabled }: { audioEnabled: boolean }) => {
-          setLocalAudioEnabled(audioEnabled);
           onAudioEnabledChange?.(audioEnabled);
 
           if (!canUseMic && audioEnabled) {
@@ -334,7 +301,6 @@ export function TownVoiceClient({
       }
 
       meetingRef.current = null;
-      setLocalAudioEnabled(false);
       onConnectionChange?.(false);
       onAudioEnabledChange?.(false);
       onAudioTogglingChange?.(false);
@@ -358,24 +324,13 @@ export function TownVoiceClient({
   ]);
 
   return (
-    <div className="space-y-4 rounded-2xl border p-5">
-      <div className="space-y-1">
-        <h3 className="text-lg font-semibold">타운 음성 방송</h3>
-        <p>현재 역할: {roleLabel}</p>
-        <p>연결 상태: {status}</p>
-        {tokenResult ? <p>preset: {tokenResult.presetName}</p> : null}
-        {errorMessage ? <p className="text-red-600">{errorMessage}</p> : null}
-      </div>
-
+    <>
+      {errorMessage ? <p className="text-red-600">{errorMessage}</p> : null}
       {status === "connected" ? (
         <RealtimeKitProvider value={client}>
-          <VoicePanel
-            isSpeaker={isSpeaker}
-            isListeningEnabled={isListeningEnabled}
-            audioEnabled={localAudioEnabled}
-          />
+          <VoicePanel isSpeaker={isSpeaker} isListeningEnabled={isListeningEnabled} />
         </RealtimeKitProvider>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/src/features/voice-chat/ui/TownVoiceClient.tsx
+++ b/src/features/voice-chat/ui/TownVoiceClient.tsx
@@ -106,9 +106,33 @@ export function TownVoiceClient({
   /** 마이크 토글 SDK 호출이 진행 중인지 동기적으로 추적하는 ref.
    *  React 리렌더 전에 발생하는 중복 클릭을 state보다 먼저 차단한다. */
   const isAudioTogglingRef = useRef(false);
+  /**
+   * 비동기 연결 흐름, SDK 이벤트 리스너, cleanup에서 최신 콜백을 읽기 위한 참조다.
+   * 메인 연결 effect가 콜백 identity 변경으로 다시 실행되지 않도록 한다.
+   */
+  const callbacksRef = useRef({
+    onConnectionChange,
+    onAudioEnabledChange,
+    onAudioControllerChange,
+    onListeningControllerChange,
+    onListeningEnabledChange,
+    onAudioTogglingChange,
+  });
 
   const hasNickname = nickname.trim().length > 0;
   const canUseMic = hasNickname && isSpeaker;
+
+  /** 매 커밋 후 최신 콜백으로 ref를 갱신해 stale callback을 방지한다. */
+  useEffect(() => {
+    callbacksRef.current = {
+      onConnectionChange,
+      onAudioEnabledChange,
+      onAudioControllerChange,
+      onListeningControllerChange,
+      onListeningEnabledChange,
+      onAudioTogglingChange,
+    };
+  });
 
   useEffect(() => {
     let isMounted = true;
@@ -123,14 +147,14 @@ export function TownVoiceClient({
       try {
         setStatus("requesting-token");
         setErrorMessage(null);
-        onAudioEnabledChange?.(false);
-        onAudioTogglingChange?.(false);
-        onAudioControllerChange?.(false, null);
-        onListeningControllerChange?.(false, null);
+        callbacksRef.current.onAudioEnabledChange?.(false);
+        callbacksRef.current.onAudioTogglingChange?.(false);
+        callbacksRef.current.onAudioControllerChange?.(false, null);
+        callbacksRef.current.onListeningControllerChange?.(false, null);
 
         listeningEnabledRef.current = false;
         setIsListeningEnabled(false);
-        onListeningEnabledChange?.(false);
+        callbacksRef.current.onListeningEnabledChange?.(false);
 
         const tokenResponse = await requestVoiceToken({
           userId,
@@ -183,7 +207,7 @@ export function TownVoiceClient({
           if (!activeMeeting || !canUseMic || !activeMeeting.self.roomJoined) return;
 
           isAudioTogglingRef.current = true;
-          onAudioTogglingChange?.(true);
+          callbacksRef.current.onAudioTogglingChange?.(true);
           try {
             if (activeMeeting.self.audioEnabled) {
               await activeMeeting.self.disableAudio();
@@ -192,7 +216,7 @@ export function TownVoiceClient({
             }
           } finally {
             isAudioTogglingRef.current = false;
-            onAudioTogglingChange?.(false);
+            callbacksRef.current.onAudioTogglingChange?.(false);
           }
         };
 
@@ -204,7 +228,7 @@ export function TownVoiceClient({
           const next = !listeningEnabledRef.current;
           listeningEnabledRef.current = next;
           setIsListeningEnabled(next);
-          onListeningEnabledChange?.(next);
+          callbacksRef.current.onListeningEnabledChange?.(next);
         };
 
         /**
@@ -212,7 +236,7 @@ export function TownVoiceClient({
          * audioUpdate 이벤트 리스너로 등록되어 마이크 상태 변화를 감지한다.
          */
         const keepAudioDisabled = ({ audioEnabled }: { audioEnabled: boolean }) => {
-          onAudioEnabledChange?.(audioEnabled);
+          callbacksRef.current.onAudioEnabledChange?.(audioEnabled);
 
           if (!canUseMic && audioEnabled) {
             void initializedMeeting.self.disableAudio();
@@ -246,8 +270,14 @@ export function TownVoiceClient({
           initializedMeeting.participants.audioSubscribed,
         );
 
-        onAudioControllerChange?.(canUseMic, canUseMic ? toggleLocalAudio : null);
-        onListeningControllerChange?.(!isSpeaker, !isSpeaker ? toggleLocalListening : null);
+        callbacksRef.current.onAudioControllerChange?.(
+          canUseMic,
+          canUseMic ? toggleLocalAudio : null,
+        );
+        callbacksRef.current.onListeningControllerChange?.(
+          !isSpeaker,
+          !isSpeaker ? toggleLocalListening : null,
+        );
 
         if (canUseMic) {
           try {
@@ -271,17 +301,17 @@ export function TownVoiceClient({
         if (!isMounted) return;
 
         setStatus("connected");
-        onConnectionChange?.(true);
+        callbacksRef.current.onConnectionChange?.(true);
       } catch (error) {
         if (!isMounted) return;
 
         setStatus("error");
-        onConnectionChange?.(false);
-        onAudioEnabledChange?.(false);
-        onAudioTogglingChange?.(false);
-        onAudioControllerChange?.(false, null);
-        onListeningControllerChange?.(false, null);
-        onListeningEnabledChange?.(true);
+        callbacksRef.current.onConnectionChange?.(false);
+        callbacksRef.current.onAudioEnabledChange?.(false);
+        callbacksRef.current.onAudioTogglingChange?.(false);
+        callbacksRef.current.onAudioControllerChange?.(false, null);
+        callbacksRef.current.onListeningControllerChange?.(false, null);
+        callbacksRef.current.onListeningEnabledChange?.(true);
         setErrorMessage(
           error instanceof Error ? error.message : "음성 연결 중 알 수 없는 오류가 발생했습니다.",
         );
@@ -301,27 +331,15 @@ export function TownVoiceClient({
       }
 
       meetingRef.current = null;
-      onConnectionChange?.(false);
-      onAudioEnabledChange?.(false);
-      onAudioTogglingChange?.(false);
-      onAudioControllerChange?.(false, null);
-      onListeningControllerChange?.(false, null);
+      callbacksRef.current.onConnectionChange?.(false);
+      callbacksRef.current.onAudioEnabledChange?.(false);
+      callbacksRef.current.onAudioTogglingChange?.(false);
+      callbacksRef.current.onAudioControllerChange?.(false, null);
+      callbacksRef.current.onListeningControllerChange?.(false, null);
       listeningEnabledRef.current = true;
-      onListeningEnabledChange?.(true);
+      callbacksRef.current.onListeningEnabledChange?.(true);
     };
-  }, [
-    initMeeting,
-    isSpeaker,
-    nickname,
-    userId,
-    onConnectionChange,
-    onAudioEnabledChange,
-    onAudioControllerChange,
-    onListeningControllerChange,
-    onListeningEnabledChange,
-    onAudioTogglingChange,
-    canUseMic,
-  ]);
+  }, [initMeeting, isSpeaker, nickname, userId, canUseMic]);
 
   return (
     <>

--- a/src/features/voice-chat/ui/TownVoiceClient.tsx
+++ b/src/features/voice-chat/ui/TownVoiceClient.tsx
@@ -26,12 +26,12 @@ export type TownVoiceClientProps = {
   onConnectionChange?: (connected: boolean) => void;
   /** 발표자의 마이크 활성 상태가 변경될 때 호출된다. */
   onAudioEnabledChange?: (enabled: boolean) => void;
-  /** 사용자 패널에서 사용할 마이크 토글 제어기가 준비될 때 호출된다. */
+  /** 툴바 음성 제어 UI에서 사용할 마이크 토글 제어기가 준비될 때 호출된다. */
   onAudioControllerChange?: (
     canToggleAudio: boolean,
     toggleAudio: (() => Promise<void>) | null,
   ) => void;
-  /** 사용자 패널에서 사용할 청취 토글 제어기가 준비될 때 호출된다. */
+  /** 툴바 음성 제어 UI에서 사용할 청취 토글 제어기가 준비될 때 호출된다. */
   onListeningControllerChange?: (
     canToggleListening: boolean,
     toggleListening: (() => Promise<void>) | null,
@@ -53,6 +53,8 @@ type ConnectionStatus =
   | "joining"
   | "connected"
   | "error";
+
+const DEFAULT_LISTENING_ENABLED = true;
 
 /**
  * 음성 채널 연결이 완료된 뒤 오디오를 재생한다.
@@ -99,10 +101,10 @@ export function TownVoiceClient({
   const [client, initMeeting] = useRealtimeKitClient();
   const [status, setStatus] = useState<ConnectionStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isListeningEnabled, setIsListeningEnabled] = useState(false);
+  const [isListeningEnabled, setIsListeningEnabled] = useState(DEFAULT_LISTENING_ENABLED);
 
   const meetingRef = useRef<typeof client | null>(null);
-  const listeningEnabledRef = useRef(true);
+  const listeningEnabledRef = useRef(DEFAULT_LISTENING_ENABLED);
   /** 마이크 토글 SDK 호출이 진행 중인지 동기적으로 추적하는 ref.
    *  React 리렌더 전에 발생하는 중복 클릭을 state보다 먼저 차단한다. */
   const isAudioTogglingRef = useRef(false);
@@ -152,9 +154,9 @@ export function TownVoiceClient({
         callbacksRef.current.onAudioControllerChange?.(false, null);
         callbacksRef.current.onListeningControllerChange?.(false, null);
 
-        listeningEnabledRef.current = false;
-        setIsListeningEnabled(false);
-        callbacksRef.current.onListeningEnabledChange?.(false);
+        listeningEnabledRef.current = DEFAULT_LISTENING_ENABLED;
+        setIsListeningEnabled(DEFAULT_LISTENING_ENABLED);
+        callbacksRef.current.onListeningEnabledChange?.(DEFAULT_LISTENING_ENABLED);
 
         const tokenResponse = await requestVoiceToken({
           userId,
@@ -231,6 +233,10 @@ export function TownVoiceClient({
           callbacksRef.current.onListeningEnabledChange?.(next);
         };
 
+        if (!isSpeaker) {
+          callbacksRef.current.onListeningControllerChange?.(true, toggleLocalListening);
+        }
+
         /**
          * 발표자가 아닌 경우 마이크를 강제로 끄도록 유지한다.
          * audioUpdate 이벤트 리스너로 등록되어 마이크 상태 변화를 감지한다.
@@ -264,14 +270,11 @@ export function TownVoiceClient({
           canUseMic,
           canUseMic ? toggleLocalAudio : null,
         );
-        callbacksRef.current.onListeningControllerChange?.(
-          !isSpeaker,
-          !isSpeaker ? toggleLocalListening : null,
-        );
-
         if (canUseMic) {
+          callbacksRef.current.onListeningControllerChange?.(false, null);
           try {
             await initializedMeeting.self.enableAudio();
+            callbacksRef.current.onAudioEnabledChange?.(true);
           } catch (audioError) {
             console.error("enableAudio error", audioError);
             if (isMounted) {
@@ -322,8 +325,8 @@ export function TownVoiceClient({
       callbacksRef.current.onAudioTogglingChange?.(false);
       callbacksRef.current.onAudioControllerChange?.(false, null);
       callbacksRef.current.onListeningControllerChange?.(false, null);
-      listeningEnabledRef.current = true;
-      callbacksRef.current.onListeningEnabledChange?.(true);
+      listeningEnabledRef.current = DEFAULT_LISTENING_ENABLED;
+      callbacksRef.current.onListeningEnabledChange?.(DEFAULT_LISTENING_ENABLED);
     };
   }, [initMeeting, isSpeaker, nickname, userId, canUseMic]);
 

--- a/src/features/voice-chat/ui/TownVoiceClient.tsx
+++ b/src/features/voice-chat/ui/TownVoiceClient.tsx
@@ -13,37 +13,14 @@ import { RtkParticipantsAudio } from "@cloudflare/realtimekit-react-ui";
 import { useEffect, useRef, useState } from "react";
 
 import { requestVoiceToken } from "../api/requestVoiceToken";
+import { TownVoiceCallbacks, useTownVoiceCallbacks } from "../hooks/useTownVoiceCallbacks";
 
 /** 타운 음성 방송에서 speaker 또는 listener로 연결하기 위한 props */
-export type TownVoiceClientProps = {
+export interface TownVoiceClientProps extends TownVoiceCallbacks {
   userId: string;
   nickname: string;
   isSpeaker: boolean;
-  /**
-   * 음성 연결 상태가 변경될 때 호출되는 콜백.
-   * connected가 true이면 연결 완료, false이면 연결 실패 또는 언마운트를 의미한다.
-   */
-  onConnectionChange?: (connected: boolean) => void;
-  /** 발표자의 마이크 활성 상태가 변경될 때 호출된다. */
-  onAudioEnabledChange?: (enabled: boolean) => void;
-  /** 툴바 음성 제어 UI에서 사용할 마이크 토글 제어기가 준비될 때 호출된다. */
-  onAudioControllerChange?: (
-    canToggleAudio: boolean,
-    toggleAudio: (() => Promise<void>) | null,
-  ) => void;
-  /** 툴바 음성 제어 UI에서 사용할 청취 토글 제어기가 준비될 때 호출된다. */
-  onListeningControllerChange?: (
-    canToggleListening: boolean,
-    toggleListening: (() => Promise<void>) | null,
-  ) => void;
-  /** 청취 on/off 상태가 변경될 때 호출된다. */
-  onListeningEnabledChange?: (enabled: boolean) => void;
-  /**
-   * 마이크 토글 SDK 호출의 진행 상태가 변경될 때 호출된다.
-   * true이면 토글 중, false이면 완료(또는 에러)를 의미한다.
-   */
-  onAudioTogglingChange?: (isToggling: boolean) => void;
-};
+}
 
 /** 음성 채널 연결 진행 상태 */
 type ConnectionStatus =
@@ -108,11 +85,14 @@ export function TownVoiceClient({
   /** 마이크 토글 SDK 호출이 진행 중인지 동기적으로 추적하는 ref.
    *  React 리렌더 전에 발생하는 중복 클릭을 state보다 먼저 차단한다. */
   const isAudioTogglingRef = useRef(false);
-  /**
-   * 비동기 연결 흐름, SDK 이벤트 리스너, cleanup에서 최신 콜백을 읽기 위한 참조다.
-   * 메인 연결 effect가 콜백 identity 변경으로 다시 실행되지 않도록 한다.
-   */
-  const callbacksRef = useRef({
+  const {
+    notifyConnectionChange,
+    notifyAudioEnabledChange,
+    notifyAudioControllerChange,
+    notifyListeningControllerChange,
+    notifyListeningEnabledChange,
+    notifyAudioTogglingChange,
+  } = useTownVoiceCallbacks({
     onConnectionChange,
     onAudioEnabledChange,
     onAudioControllerChange,
@@ -123,18 +103,6 @@ export function TownVoiceClient({
 
   const hasNickname = nickname.trim().length > 0;
   const canUseMic = hasNickname && isSpeaker;
-
-  /** 매 커밋 후 최신 콜백으로 ref를 갱신해 stale callback을 방지한다. */
-  useEffect(() => {
-    callbacksRef.current = {
-      onConnectionChange,
-      onAudioEnabledChange,
-      onAudioControllerChange,
-      onListeningControllerChange,
-      onListeningEnabledChange,
-      onAudioTogglingChange,
-    };
-  });
 
   useEffect(() => {
     let isMounted = true;
@@ -149,14 +117,14 @@ export function TownVoiceClient({
       try {
         setStatus("requesting-token");
         setErrorMessage(null);
-        callbacksRef.current.onAudioEnabledChange?.(false);
-        callbacksRef.current.onAudioTogglingChange?.(false);
-        callbacksRef.current.onAudioControllerChange?.(false, null);
-        callbacksRef.current.onListeningControllerChange?.(false, null);
+        notifyAudioEnabledChange(false);
+        notifyAudioTogglingChange(false);
+        notifyAudioControllerChange(false, null);
+        notifyListeningControllerChange(false, null);
 
         listeningEnabledRef.current = DEFAULT_LISTENING_ENABLED;
         setIsListeningEnabled(DEFAULT_LISTENING_ENABLED);
-        callbacksRef.current.onListeningEnabledChange?.(DEFAULT_LISTENING_ENABLED);
+        notifyListeningEnabledChange(DEFAULT_LISTENING_ENABLED);
 
         const tokenResponse = await requestVoiceToken({
           userId,
@@ -209,7 +177,7 @@ export function TownVoiceClient({
           if (!activeMeeting || !canUseMic || !activeMeeting.self.roomJoined) return;
 
           isAudioTogglingRef.current = true;
-          callbacksRef.current.onAudioTogglingChange?.(true);
+          notifyAudioTogglingChange(true);
           try {
             if (activeMeeting.self.audioEnabled) {
               await activeMeeting.self.disableAudio();
@@ -218,7 +186,7 @@ export function TownVoiceClient({
             }
           } finally {
             isAudioTogglingRef.current = false;
-            callbacksRef.current.onAudioTogglingChange?.(false);
+            notifyAudioTogglingChange(false);
           }
         };
 
@@ -230,11 +198,11 @@ export function TownVoiceClient({
           const next = !listeningEnabledRef.current;
           listeningEnabledRef.current = next;
           setIsListeningEnabled(next);
-          callbacksRef.current.onListeningEnabledChange?.(next);
+          notifyListeningEnabledChange(next);
         };
 
         if (!isSpeaker) {
-          callbacksRef.current.onListeningControllerChange?.(true, toggleLocalListening);
+          notifyListeningControllerChange(true, toggleLocalListening);
         }
 
         /**
@@ -242,7 +210,7 @@ export function TownVoiceClient({
          * audioUpdate 이벤트 리스너로 등록되어 마이크 상태 변화를 감지한다.
          */
         const keepAudioDisabled = ({ audioEnabled }: { audioEnabled: boolean }) => {
-          callbacksRef.current.onAudioEnabledChange?.(audioEnabled);
+          notifyAudioEnabledChange(audioEnabled);
 
           if (!canUseMic && audioEnabled) {
             void initializedMeeting.self.disableAudio();
@@ -266,15 +234,12 @@ export function TownVoiceClient({
           await initializedMeeting.self.disableAudio();
         }
 
-        callbacksRef.current.onAudioControllerChange?.(
-          canUseMic,
-          canUseMic ? toggleLocalAudio : null,
-        );
+        notifyAudioControllerChange(canUseMic, canUseMic ? toggleLocalAudio : null);
         if (canUseMic) {
-          callbacksRef.current.onListeningControllerChange?.(false, null);
+          notifyListeningControllerChange(false, null);
           try {
             await initializedMeeting.self.enableAudio();
-            callbacksRef.current.onAudioEnabledChange?.(true);
+            notifyAudioEnabledChange(true);
           } catch (audioError) {
             console.error("enableAudio error", audioError);
             if (isMounted) {
@@ -290,17 +255,17 @@ export function TownVoiceClient({
         if (!isMounted) return;
 
         setStatus("connected");
-        callbacksRef.current.onConnectionChange?.(true);
+        notifyConnectionChange(true);
       } catch (error) {
         if (!isMounted) return;
 
         setStatus("error");
-        callbacksRef.current.onConnectionChange?.(false);
-        callbacksRef.current.onAudioEnabledChange?.(false);
-        callbacksRef.current.onAudioTogglingChange?.(false);
-        callbacksRef.current.onAudioControllerChange?.(false, null);
-        callbacksRef.current.onListeningControllerChange?.(false, null);
-        callbacksRef.current.onListeningEnabledChange?.(true);
+        notifyConnectionChange(false);
+        notifyAudioEnabledChange(false);
+        notifyAudioTogglingChange(false);
+        notifyAudioControllerChange(false, null);
+        notifyListeningControllerChange(false, null);
+        notifyListeningEnabledChange(true);
         setErrorMessage(
           error instanceof Error ? error.message : "음성 연결 중 알 수 없는 오류가 발생했습니다.",
         );
@@ -320,15 +285,27 @@ export function TownVoiceClient({
       }
 
       meetingRef.current = null;
-      callbacksRef.current.onConnectionChange?.(false);
-      callbacksRef.current.onAudioEnabledChange?.(false);
-      callbacksRef.current.onAudioTogglingChange?.(false);
-      callbacksRef.current.onAudioControllerChange?.(false, null);
-      callbacksRef.current.onListeningControllerChange?.(false, null);
+      notifyConnectionChange(false);
+      notifyAudioEnabledChange(false);
+      notifyAudioTogglingChange(false);
+      notifyAudioControllerChange(false, null);
+      notifyListeningControllerChange(false, null);
       listeningEnabledRef.current = DEFAULT_LISTENING_ENABLED;
-      callbacksRef.current.onListeningEnabledChange?.(DEFAULT_LISTENING_ENABLED);
+      notifyListeningEnabledChange(DEFAULT_LISTENING_ENABLED);
     };
-  }, [initMeeting, isSpeaker, nickname, userId, canUseMic]);
+  }, [
+    initMeeting,
+    isSpeaker,
+    nickname,
+    userId,
+    canUseMic,
+    notifyConnectionChange,
+    notifyAudioEnabledChange,
+    notifyAudioControllerChange,
+    notifyListeningControllerChange,
+    notifyListeningEnabledChange,
+    notifyAudioTogglingChange,
+  ]);
 
   return (
     <>

--- a/src/widgets/townToolbar/ui/TownToolbar.tsx
+++ b/src/widgets/townToolbar/ui/TownToolbar.tsx
@@ -3,14 +3,22 @@
 import { useTownPanelToggleStore } from "@/features/panelToggle";
 import { PresenceToolbarButton } from "@/features/presence";
 
-export function TownToolbar() {
+interface TownToolbarProps {
+  isSpeaker: boolean;
+}
+
+export function TownToolbar({ isSpeaker }: TownToolbarProps) {
   const activePanel = useTownPanelToggleStore((state) => state.activePanel);
   const togglePanel = useTownPanelToggleStore((state) => state.togglePanel);
   const isUsersPanel = activePanel === "users";
 
   return (
     <div className="flex h-12 w-full items-center justify-end  border-t bg-white px-4">
-      <PresenceToolbarButton isUsersPanel={isUsersPanel} onToggle={togglePanel} />
+      <PresenceToolbarButton
+        isSpeaker={isSpeaker}
+        isUsersPanel={isUsersPanel}
+        onToggle={togglePanel}
+      />
     </div>
   );
 }

--- a/src/widgets/townVoiceSection/index.ts
+++ b/src/widgets/townVoiceSection/index.ts
@@ -1,0 +1,1 @@
+export { TownVoiceSection } from "./ui/TownVoiceSection";

--- a/src/widgets/townVoiceSection/ui/TownVoiceSection.tsx
+++ b/src/widgets/townVoiceSection/ui/TownVoiceSection.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTownPresenceStore } from "@/features/presence/model/useTownPresenceStore";
+import { TownVoiceClient } from "@/features/voice-chat";
+
+import { useEffect } from "react";
+
+interface TownVoiceSectionProps {
+  userId: string;
+  userNickname: string;
+}
+
+export function TownVoiceSection({ userId, userNickname }: TownVoiceSectionProps) {
+  const isSpeaker = userNickname === process.env.NEXT_PUBLIC_SPEAKER_NICKNAME;
+  const setVoiceConnected = useTownPresenceStore((state) => state.setVoiceConnected);
+  const setIsSpeaker = useTownPresenceStore((state) => state.setIsSpeaker);
+  const setAudioEnabled = useTownPresenceStore((state) => state.setAudioEnabled);
+  const setAudioController = useTownPresenceStore((state) => state.setAudioController);
+  const setListeningController = useTownPresenceStore((state) => state.setListeningController);
+  const setListeningEnabled = useTownPresenceStore((state) => state.setListeningEnabled);
+  const setAudioToggling = useTownPresenceStore((state) => state.setAudioToggling);
+
+  /** 툴바와 사용자 패널이 현재 사용자의 역할 정보를 공통 store에서 읽도록 맞춘다. */
+  useEffect(() => {
+    setIsSpeaker(isSpeaker);
+  }, [isSpeaker, setIsSpeaker]);
+
+  return (
+    <TownVoiceClient
+      userId={userId}
+      nickname={userNickname}
+      isSpeaker={isSpeaker}
+      onConnectionChange={setVoiceConnected}
+      onAudioEnabledChange={setAudioEnabled}
+      onAudioControllerChange={setAudioController}
+      onAudioTogglingChange={setAudioToggling}
+      onListeningControllerChange={setListeningController}
+      onListeningEnabledChange={setListeningEnabled}
+    />
+  );
+}

--- a/src/widgets/townVoiceSection/ui/TownVoiceSection.tsx
+++ b/src/widgets/townVoiceSection/ui/TownVoiceSection.tsx
@@ -3,27 +3,19 @@
 import { useTownPresenceStore } from "@/features/presence/model/useTownPresenceStore";
 import { TownVoiceClient } from "@/features/voice-chat";
 
-import { useEffect } from "react";
-
 interface TownVoiceSectionProps {
   userId: string;
   userNickname: string;
+  isSpeaker: boolean;
 }
 
-export function TownVoiceSection({ userId, userNickname }: TownVoiceSectionProps) {
-  const isSpeaker = userNickname === process.env.NEXT_PUBLIC_SPEAKER_NICKNAME;
+export function TownVoiceSection({ userId, userNickname, isSpeaker }: TownVoiceSectionProps) {
   const setVoiceConnected = useTownPresenceStore((state) => state.setVoiceConnected);
-  const setIsSpeaker = useTownPresenceStore((state) => state.setIsSpeaker);
   const setAudioEnabled = useTownPresenceStore((state) => state.setAudioEnabled);
   const setAudioController = useTownPresenceStore((state) => state.setAudioController);
   const setListeningController = useTownPresenceStore((state) => state.setListeningController);
   const setListeningEnabled = useTownPresenceStore((state) => state.setListeningEnabled);
   const setAudioToggling = useTownPresenceStore((state) => state.setAudioToggling);
-
-  /** 툴바와 사용자 패널이 현재 사용자의 역할 정보를 공통 store에서 읽도록 맞춘다. */
-  useEffect(() => {
-    setIsSpeaker(isSpeaker);
-  }, [isSpeaker, setIsSpeaker]);
 
   return (
     <TownVoiceClient

--- a/src/widgets/usersPanel/ui/UsersPanel.tsx
+++ b/src/widgets/usersPanel/ui/UsersPanel.tsx
@@ -11,35 +11,31 @@ import { useShallow } from "zustand/react/shallow";
 /**
  * 다른 사용자의 음성 상태를 나타내는 아이콘을 렌더링한다.
  *
- * 발표자는 마이크가 활성화되었을 때 초록색 마이크 아이콘을 표시하고,
- * 청취자는 음성 채널에 연결되었을 때 초록색 헤드셋 아이콘을 표시한다.
+ * 발표자는 마이크 활성 시 초록색, 비활성 시 회색 마이크 아이콘을 표시한다.
+ * 청취자는 음성 채널에 연결된 경우 초록색, 미연결 시 회색 헤드셋 아이콘을 표시한다.
  */
 const renderVoiceIndicator = (participant: PresenceParticipant) => {
   if (participant.isSpeaker) {
-    if (!participant.audioEnabled) {
-      return null;
-    }
-
     return (
       <span
-        className="inline-flex items-center text-emerald-500"
-        aria-label="발표 중"
-        title="발표 중"
+        className={`inline-flex items-center ${
+          participant.audioEnabled ? "text-emerald-500" : "text-gray-300"
+        }`}
+        aria-label={participant.audioEnabled ? "마이크 활성" : "마이크 비활성"}
+        title={participant.audioEnabled ? "마이크 활성" : "마이크 비활성"}
       >
         <Mic className="size-3.5" aria-hidden="true" />
       </span>
     );
   }
 
-  if (!participant.voiceConnected) {
-    return null;
-  }
-
   return (
     <span
-      className="inline-flex items-center text-emerald-500"
-      aria-label="청취 중"
-      title="청취 중"
+      className={`inline-flex items-center ${
+        participant.voiceConnected ? "text-emerald-500" : "text-gray-300"
+      }`}
+      aria-label={participant.voiceConnected ? "청취 중" : "청취 미연결"}
+      title={participant.voiceConnected ? "청취 중" : "청취 미연결"}
     >
       <Headphones className="size-3.5" aria-hidden="true" />
     </span>
@@ -49,69 +45,31 @@ const renderVoiceIndicator = (participant: PresenceParticipant) => {
 /**
  * 현재 사용자 row는 presence 재동기화보다 로컬 음성 상태를 우선 사용해
  * 아이콘이 즉시 반응하도록 한다.
+ *
+ * 청취자의 경우 voiceConnected와 listeningEnabled가 모두 true일 때만
+ * 연결된 것으로 간주해 헤드폰 아이콘을 초록색으로 표시한다.
  */
 const getResolvedParticipant = (
   participant: PresenceParticipant,
   currentUserId: string | undefined,
   localVoiceConnected: boolean,
   localAudioEnabled: boolean,
+  localListeningEnabled: boolean,
 ) => {
   if (participant.userId !== currentUserId) {
     return participant;
   }
 
+  const resolvedVoiceConnected = participant.isSpeaker
+    ? localVoiceConnected
+    : localVoiceConnected && localListeningEnabled;
+
   return {
     ...participant,
-    voiceConnected: localVoiceConnected,
+    voiceConnected: resolvedVoiceConnected,
     audioEnabled: localAudioEnabled,
   };
 };
-
-/**
- * 발표자인 현재 사용자의 마이크 토글 버튼을 렌더링한다.
- *
- * isToggling이 true인 동안 버튼을 disabled 처리해
- * SDK enableAudio/disableAudio 호출이 완료되기 전에 중복 클릭되지 않도록 막는다.
- */
-const renderSpeakerControl = (
-  audioEnabled: boolean | undefined,
-  onToggle: () => Promise<void>,
-  isToggling: boolean,
-) => (
-  <button
-    type="button"
-    onClick={() => void onToggle()}
-    disabled={isToggling}
-    className={`inline-flex cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 disabled:cursor-not-allowed disabled:opacity-50 ${
-      audioEnabled ? "text-emerald-500 hover:text-emerald-600" : "text-gray-300 hover:text-gray-500"
-    }`}
-    aria-label={audioEnabled ? "마이크 끄기" : "마이크 켜기"}
-    aria-pressed={audioEnabled}
-    title={audioEnabled ? "마이크 끄기" : "마이크 켜기"}
-  >
-    <Mic className="size-3.5" aria-hidden="true" />
-  </button>
-);
-
-/**
- * 청취자인 현재 사용자의 청취 토글 버튼을 렌더링한다.
- */
-const renderListenerControl = (listeningEnabled: boolean, onToggle: () => Promise<void>) => (
-  <button
-    type="button"
-    onClick={() => void onToggle()}
-    className={`inline-flex cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 ${
-      listeningEnabled
-        ? "text-emerald-500 hover:text-emerald-600"
-        : "text-gray-300 hover:text-gray-500"
-    }`}
-    aria-label={listeningEnabled ? "청취 끄기" : "청취 켜기"}
-    aria-pressed={listeningEnabled}
-    title={listeningEnabled ? "청취 끄기" : "청취 켜기"}
-  >
-    <Headphones className="size-3.5" aria-hidden="true" />
-  </button>
-);
 
 export function UsersPanel() {
   const { data: user } = useUserInfo();
@@ -121,12 +79,7 @@ export function UsersPanel() {
     isConnected,
     localVoiceConnected,
     localAudioEnabled,
-    canToggleAudio,
-    toggleLocalAudio,
-    isAudioToggling,
-    canToggleListening,
     localListeningEnabled,
-    toggleLocalListening,
   } = useTownPresenceStore(
     useShallow((state) => ({
       groupedParticipants: state.groupedParticipants,
@@ -134,12 +87,7 @@ export function UsersPanel() {
       isConnected: state.isConnected,
       localVoiceConnected: state.voiceConnected,
       localAudioEnabled: state.audioEnabled,
-      canToggleAudio: state.canToggleAudio,
-      toggleLocalAudio: state.toggleLocalAudio,
-      isAudioToggling: state.isAudioToggling,
-      canToggleListening: state.canToggleListening,
       localListeningEnabled: state.listeningEnabled,
-      toggleLocalListening: state.toggleLocalListening,
     })),
   );
   const presenceStatus = isConnected ? "실시간으로 동기화 중" : "연결 대기 중";
@@ -155,21 +103,9 @@ export function UsersPanel() {
         currentUserId,
         localVoiceConnected,
         localAudioEnabled,
+        localListeningEnabled,
       );
-      const isCurrentUser = resolvedParticipant.userId === currentUserId;
-      const voiceControl = (() => {
-        if (!isCurrentUser) return renderVoiceIndicator(resolvedParticipant);
-        if (resolvedParticipant.isSpeaker) {
-          if (!canToggleAudio || !toggleLocalAudio) return null;
-          return renderSpeakerControl(
-            resolvedParticipant.audioEnabled,
-            toggleLocalAudio,
-            isAudioToggling,
-          );
-        }
-        if (!canToggleListening || !toggleLocalListening) return null;
-        return renderListenerControl(localListeningEnabled, toggleLocalListening);
-      })();
+      const voiceControl = renderVoiceIndicator(resolvedParticipant);
 
       return (
         <div


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- `#108` 아키텍처 개선 항목 중 음성 UI 정리, `TownVoiceClient` 콜백 안정화, 음성 조합 로직의widget 레이어 분리를 반영했습니다.
  - `UsersPanel`은 음성 토글을 제거하고 상태 표시 전용 UI로 정리했습니다.
  - `PresenceToolbar`는 음성 제어 영역과 사용자 패널 토글 영역을 역할별 컴포넌트로 분리했습니다.
  - `TownVoiceClient`는 `callbacksRef.current`를 사용해 비동기 연결 흐름과 cleanup에서 최신 콜백을 읽도록 정리했습니다.
  - `TownPage`에 있던 음성 관련 비즈니스 조합은 `TownVoiceSection` widget으로 분리했습니다.
 

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)
<img width="1159" height="86" alt="스크린샷 2026-04-24 오후 9 35 27" src="https://github.com/user-attachments/assets/8319aaf0-762a-4cef-bd53-f40ba8c33d17" />

<img width="1153" height="70" alt="스크린샷 2026-04-24 오후 9 40 49" src="https://github.com/user-attachments/assets/cfcd74e5-b047-4285-b824-b872e0727537" />


## 💬 추가 전달사항

 - **주의깊게 봐주길 원하는 부분:** `TownVoiceClient`의 `callbacksRef.current` 패턴이 현재 비동기 연결 흐름에서 적절한지
 - **기타 참고사항:** 이슈 #108 의 “Zustand 스토어에 함수를 직접 저장하는 패턴 재설계”는 현재 설치된 Zustand 버전/타입 제약으로 이번 PR 범위에서 진행하지 않았습니다.
 - **머지 순서 참고:** 작업 흐름상 서윤님 #82 PR이 먼저 머지된 뒤 이 PR을 머지하는 편이 안전할 것 같습니다.
 
  ### `callbacksRef.current`와 `useEffectEvent` 비교
  
  
  - `stale callback`은 비동기 함수, 이벤트 리스너, cleanup이 예전 렌더 시점의 콜백을 계속 참조하는 상태를 의미합니다.
  이번 변경에서는 실행 시점에 최신 콜백을 읽도록 해 이 문제를 방지했습니다.

  | 항목 | `callbacksRef.current` | `useEffectEvent` |
  |---|---|---|
  | 핵심 아이디어 | 최신 콜백을 `ref`에 보관하고 실행 시점에 읽음 | 최신 콜백을 읽는 event 함수를 React가 관리 |
  | stale callback 방지 | 가능 | 가능 |
  | 비동기 함수 / cleanup 대응 | 잘 맞음 | 잘 맞음 |
  | 가독성 | ref 관리 코드가 보여 다소 저수준 | 더 선언적으로 읽힘 |
  | 코드베이스 일관성 | 현재 도파민또 기준 더 안전함 | 사용 기준이 없으면 단독 도입이 어색할 수 있음 |
  | 이번 PR 판단 | 채택 | 보류 |

  - **함께 고민하고 싶은 부분:** `useEffectEvent`도 대안이 될 수 있었지만, 현재 저희 프로젝트에서는 사용 기준이 아직 명확하지
  않아 단독 도입 시 패턴 일관성이 약해지고 이해 비용이 커질 수 있다고 판단했습니다. 이번 PR에서는 비동기 연결 흐름과 cleanup에서 최
  신 콜백을 안전하게 읽기 위해 `callbacksRef.current`를 선택했습니다