### PR TITLE
[refactor]  신규 입장자 안전 스폰 보정 적용 (#121)

### DIFF
--- a/src/features/movement/hooks/useRestorePlayerPosition.ts
+++ b/src/features/movement/hooks/useRestorePlayerPosition.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { VillageId } from "@/entities/village";
+import { LOBBY_VILLAGE_ID, VillageId } from "@/entities/village";
 import { fetchPlayerPosition } from "@/features/movement/lib/playerPositionService";
 import { isValidSavedPosition } from "@/features/movement/lib/validateMovement";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
@@ -24,27 +24,55 @@ export function useRestorePlayerPosition() {
     // 유저 정보 로딩 중에는 대기
     if (isUserLoading) return;
 
+    let isCancelled = false;
+
     // async IIFE로 감싸 setState가 마이크로태스크에서 호출되도록 한다.
     // (useEffect 내 동기 setState는 불필요한 렌더 연쇄를 유발할 수 있다)
     void (async () => {
+      /**
+       * 저장 위치가 없거나 복원할 수 없을 때는 useMovementStore의 현재 초기 위치를
+       * 안전 스폰 보정 경로로 확정해 기존 randomized fallback을 유지한다.
+       */
+      const initializeDefaultSpawn = () => {
+        if (isCancelled) return;
+
+        const { position } = useMovementStore.getState();
+        initializePosition(position, LOBBY_VILLAGE_ID);
+      };
+
       try {
         if (user) {
           const saved = await fetchPlayerPosition(user.id);
 
+          if (isCancelled) return;
+
           if (saved && isValidSavedPosition(saved.village_id, { x: saved.x, y: saved.y })) {
             // 유효한 저장 위치가 있으면 스토어에 반영
             initializePosition({ x: saved.x, y: saved.y }, saved.village_id as VillageId);
+          } else {
+            // 저장 위치가 없거나 유효하지 않으면 기본 스폰 위치도 안전 보정 경로를 거친다.
+            initializeDefaultSpawn();
           }
-          // 저장 위치가 없거나 유효하지 않으면 기본 스폰 위치(로비) 유지
+        } else {
+          initializeDefaultSpawn();
         }
       } catch (err) {
+        if (isCancelled) return;
+
         // 조회 실패 시 기본 위치로 진입, 실패는 로깅
+        initializeDefaultSpawn();
         console.error("[useRestorePlayerPosition] 위치 조회 실패:", err);
       } finally {
+        if (isCancelled) return;
+
         // 성공/실패 모두 엔진 마운트를 허용
         setIsReady(true);
       }
     })();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [user, isUserLoading, initializePosition]);
 
   return { isReady };

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -15,6 +15,9 @@ import { RemotePlayer } from "@/features/movement/model/types";
 import * as Phaser from "phaser";
 
 const CAPTURED_KEYS = "W,A,S,D,UP,DOWN,LEFT,RIGHT,SPACE";
+const CHARACTER_DEPTH_BASE = 1000;
+const NAME_LABEL_DEPTH_OFFSET = 1;
+const DEBUG_TEXT_DEPTH = 10000;
 
 export class TownScene extends Phaser.Scene {
   private player!: Phaser.GameObjects.Sprite;
@@ -79,7 +82,6 @@ export class TownScene extends Phaser.Scene {
 
     this.player = this.add.sprite(initialPos.x, initialPos.y, localCharacterConfig.assetKey, 0); // 기본 정지 프레임(정면, 양발)
     this.applyCharacterConfig(this.player, localCharacterConfig);
-    this.player.setDepth(10); // 로컬 플레이어를 최상단에
 
     this.playerNameLabel = this.add.text(
       initialPos.x,
@@ -93,7 +95,7 @@ export class TownScene extends Phaser.Scene {
       },
     );
     this.playerNameLabel.setOrigin(0.5, 1); // 이름표의 바닥을 기준점으로 설정
-    this.playerNameLabel.setDepth(11);
+    this.syncCharacterDepth(this.player, this.playerNameLabel);
 
     this.cursors = this.input.keyboard!.createCursorKeys();
     this.wasd = this.input.keyboard!.addKeys("W,A,S,D") as {
@@ -120,7 +122,7 @@ export class TownScene extends Phaser.Scene {
         backgroundColor: "#000000aa",
       })
       .setScrollFactor(0)
-      .setDepth(100);
+      .setDepth(DEBUG_TEXT_DEPTH);
 
     // 마을 경계선 및 이름 초기화 (한 번만 생성)
     Object.values(VILLAGES).forEach((village) => {
@@ -258,6 +260,7 @@ export class TownScene extends Phaser.Scene {
         );
         nameLabel.setOrigin(0.5, 1); // 이름표의 바닥을 기준점으로 설정
         this.remotePlayerNames.set(userId, nameLabel);
+        this.syncCharacterDepth(sprite, nameLabel);
       } else {
         if (sprite.texture.key !== characterConfig.assetKey) {
           this.applyCharacterConfig(sprite, characterConfig);
@@ -333,6 +336,7 @@ export class TownScene extends Phaser.Scene {
           const remotePlayer = store.remotePlayers[userId];
           const characterConfig = getCharacterConfig(remotePlayer?.characterId);
           nameLabel.setPosition(sprite.x, sprite.y - characterConfig.labelOffsetY);
+          this.syncCharacterDepth(sprite, nameLabel);
         }
       }
     });
@@ -419,6 +423,7 @@ export class TownScene extends Phaser.Scene {
         this.player.x,
         this.player.y - getCharacterConfig(this.localCharacterId).labelOffsetY,
       );
+      this.syncCharacterDepth(this.player, this.playerNameLabel);
     }
   };
 
@@ -442,5 +447,18 @@ export class TownScene extends Phaser.Scene {
     sprite.setTexture(characterConfig.assetKey, sprite.frame.name);
     sprite.setScale(characterConfig.scale);
     sprite.setOrigin(0.5, characterConfig.originY); // 모든 캐릭터는 발밑 기준으로 정렬
+  }
+
+  /**
+   * 캐릭터의 발밑 y좌표를 기준으로 렌더링 순서를 맞춘다.
+   * 같은 공간에 여러 캐릭터가 있을 때 아래쪽 캐릭터가 위에 그려져 공중에 가려져 보이지 않게 한다.
+   */
+  private syncCharacterDepth(
+    sprite: Phaser.GameObjects.Sprite,
+    nameLabel?: Phaser.GameObjects.Text,
+  ) {
+    const spriteDepth = CHARACTER_DEPTH_BASE + sprite.y;
+    sprite.setDepth(spriteDepth);
+    nameLabel?.setDepth(spriteDepth + NAME_LABEL_DEPTH_OFFSET);
   }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

신규 사용자가 저장된 위치 없이 입장할 때 기본 스폰 위치가 겹쳐 보일 수 있는 문제를 수정했습니다.

  - 저장 위치가 없거나 유효하지 않은 경우에도 `initializePosition`을 통해 안전 스폰 보정 경로를 거치도록 변경
  - 기존 randomized fallback 위치를 유지하도록 현재 movement store의 초기 위치를 기준으로 안전 스폰 처리
  - 위치 복원 요청 중 사용자가 변경되는 경우 이전 비동기 결과가 최신 사용자 위치 를 덮어쓰지 않도록 cleanup guard 추가
  - 캐릭터 y좌표 기준으로 depth를 동기화해 여러 캐릭터가 가까이 있을 때 한쪽 캐릭터가 가려져 사라져 보이는 현상 완화

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)



## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
   - 저장된 위치가 없는 신규 사용자가 입장했을 때, 모두 같은 기본 좌표에 생성되
  지 않고 서로 떨어진 위치에 보이는지 확인 부탁드립니다.
    - 저장된 위치가 잘못된 경우에도 캐릭터가 이상한 위치로 가지 않고 로비의 안전
  한 위치에 생성되는지 확인 부탁드립니다.
    - 두 브라우저 또는 두 탭으로 동시에 입장했을 때, 한쪽 캐릭터가 겹치거나 사라
  져 보이지 않는지 확인 부탁드립니다.
    - 기존에 저장된 위치가 있는 사용자는 이전처럼 저장된 위치로 정상 복원되는지
  확인 부탁드립니다.