### PR TITLE
[feature] 신규 사용자 동시 입장 시 초기 겹침 노출 완화 (#124)

### DIFF
--- a/src/features/movement/hooks/useRestorePlayerPosition.ts
+++ b/src/features/movement/hooks/useRestorePlayerPosition.ts
@@ -8,6 +8,13 @@ import { useUserInfo } from "@/shared/hooks/useUserInfo";
 
 import { useEffect, useState } from "react";
 
+export type RestoreStatus = "loading" | "restored" | "fallback";
+
+interface RestorePlayerPositionState {
+  isReady: boolean;
+  restoreStatus: RestoreStatus;
+}
+
 /**
  * 접속 시 Supabase user_position 테이블에서 마지막 저장 위치를 조회하고,
  * 유효하면 스토어에 초기 위치로 적용한다.
@@ -16,7 +23,10 @@ import { useEffect, useState } from "react";
  * 기본 위치에 잠깐 나타났다가 저장 위치로 이동하는 텔레포트 현상을 방지한다.
  */
 export function useRestorePlayerPosition() {
-  const [isReady, setIsReady] = useState(false);
+  const [restoreState, setRestoreState] = useState<RestorePlayerPositionState>({
+    isReady: false,
+    restoreStatus: "loading",
+  });
   const { data: user, isLoading: isUserLoading } = useUserInfo();
   const initializePosition = useMovementStore((state) => state.initializePosition);
 
@@ -49,24 +59,23 @@ export function useRestorePlayerPosition() {
           if (saved && isValidSavedPosition(saved.village_id, { x: saved.x, y: saved.y })) {
             // 유효한 저장 위치가 있으면 스토어에 반영
             initializePosition({ x: saved.x, y: saved.y }, saved.village_id as VillageId);
+            setRestoreState({ isReady: true, restoreStatus: "restored" });
           } else {
             // 저장 위치가 없거나 유효하지 않으면 기본 스폰 위치도 안전 보정 경로를 거친다.
             initializeDefaultSpawn();
+            setRestoreState({ isReady: true, restoreStatus: "fallback" });
           }
         } else {
           initializeDefaultSpawn();
+          setRestoreState({ isReady: true, restoreStatus: "fallback" });
         }
       } catch (err) {
         if (isCancelled) return;
 
         // 조회 실패 시 기본 위치로 진입, 실패는 로깅
         initializeDefaultSpawn();
+        setRestoreState({ isReady: true, restoreStatus: "fallback" });
         console.error("[useRestorePlayerPosition] 위치 조회 실패:", err);
-      } finally {
-        if (isCancelled) return;
-
-        // 성공/실패 모두 엔진 마운트를 허용
-        setIsReady(true);
       }
     })();
 
@@ -75,5 +84,5 @@ export function useRestorePlayerPosition() {
     };
   }, [user, isUserLoading, initializePosition]);
 
-  return { isReady };
+  return restoreState;
 }

--- a/src/features/movement/hooks/useRestorePlayerPosition.ts
+++ b/src/features/movement/hooks/useRestorePlayerPosition.ts
@@ -3,12 +3,11 @@
 import { LOBBY_VILLAGE_ID, VillageId } from "@/entities/village";
 import { fetchPlayerPosition } from "@/features/movement/lib/playerPositionService";
 import { isValidSavedPosition } from "@/features/movement/lib/validateMovement";
+import type { RestoreStatus } from "@/features/movement/model/types";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { useUserInfo } from "@/shared/hooks/useUserInfo";
 
 import { useEffect, useState } from "react";
-
-export type RestoreStatus = "loading" | "restored" | "fallback";
 
 interface RestorePlayerPositionState {
   isReady: boolean;

--- a/src/features/movement/model/entryGate.ts
+++ b/src/features/movement/model/entryGate.ts
@@ -1,0 +1,51 @@
+import type { RestoreStatus } from "@/features/movement/model/types";
+
+export const FALLBACK_SPAWN_STABILIZE_MS = 400;
+
+interface ResolveTownEntryGateParams {
+  isReady: boolean;
+  restoreStatus: RestoreStatus;
+  fallbackWaitElapsed: boolean;
+}
+
+interface TownEntryGate {
+  canMountEngine: boolean;
+  showPreparing: boolean;
+  shouldFadeIn: boolean;
+}
+
+export const resolveTownEntryGate = ({
+  isReady,
+  restoreStatus,
+  fallbackWaitElapsed,
+}: ResolveTownEntryGateParams): TownEntryGate => {
+  if (!isReady || restoreStatus === "loading") {
+    return {
+      canMountEngine: false,
+      showPreparing: true,
+      shouldFadeIn: false,
+    };
+  }
+
+  if (restoreStatus === "restored") {
+    return {
+      canMountEngine: true,
+      showPreparing: false,
+      shouldFadeIn: false,
+    };
+  }
+
+  if (!fallbackWaitElapsed) {
+    return {
+      canMountEngine: false,
+      showPreparing: true,
+      shouldFadeIn: false,
+    };
+  }
+
+  return {
+    canMountEngine: true,
+    showPreparing: false,
+    shouldFadeIn: true,
+  };
+};

--- a/src/features/movement/model/entryGate.ts
+++ b/src/features/movement/model/entryGate.ts
@@ -1,5 +1,8 @@
 import type { RestoreStatus } from "@/features/movement/model/types";
 
+/**
+ * Realtime presence 초기 반영 여지를 주되, 긴 로딩으로 느껴지지 않도록 짧게 둔 완화 시간
+ */
 export const FALLBACK_SPAWN_STABILIZE_MS = 400;
 
 interface ResolveTownEntryGateParams {

--- a/src/features/movement/model/types.ts
+++ b/src/features/movement/model/types.ts
@@ -8,6 +8,8 @@ export const MOVEMENT_EVENT_TYPES = {
 
 export type MovementEventType = (typeof MOVEMENT_EVENT_TYPES)[keyof typeof MOVEMENT_EVENT_TYPES];
 
+export type RestoreStatus = "loading" | "restored" | "fallback";
+
 export interface Position {
   x: number;
   y: number;

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -1,7 +1,3 @@
-/**
- * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
- * 위치 복원 상태와 연동하여 게임 인스턴스의 초기화 타이밍을 제어함
- */
 "use client";
 
 import { useMovementSync } from "@/features/movement/hooks/useMovementSync";

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -16,19 +16,10 @@ import {
 import type { RestoreStatus } from "@/features/movement/model/types";
 import { MovementOverlay } from "@/features/movement/ui/MovementOverlay";
 import { TownEntryPreparing } from "@/features/movement/ui/TownEntryPreparing";
+import { cn } from "@/lib/utils";
 import * as Phaser from "phaser";
 
 import React, { useEffect, useRef, useState } from "react";
-
-/**
- * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
- * 위치 복원 상태와 연동하여 게임 인스턴스의 초기화 타이밍을 제어함
- */
-
-/**
- * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
- * 위치 복원 상태와 연동하여 게임 인스턴스의 초기화 타이밍을 제어함
- */
 
 /**
  * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
@@ -43,6 +34,7 @@ export const TownEngine = () => {
   const gameContainerRef = useRef<HTMLDivElement>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
   const [fallbackWaitElapsed, setFallbackWaitElapsed] = useState(false);
+  const [engineVisible, setEngineVisible] = useState(false);
   const [previousRestoreStatus, setPreviousRestoreStatus] = useState<RestoreStatus>("loading");
 
   /**
@@ -53,6 +45,7 @@ export const TownEngine = () => {
   if (previousRestoreStatus !== restoreStatus) {
     setPreviousRestoreStatus(restoreStatus);
     setFallbackWaitElapsed(false);
+    setEngineVisible(false);
   }
 
   const entryGate = resolveTownEntryGate({
@@ -100,8 +93,12 @@ export const TownEngine = () => {
     };
 
     gameRef.current = new Phaser.Game(config);
+    const frameId = requestAnimationFrame(() => {
+      setEngineVisible(true);
+    });
 
     return () => {
+      cancelAnimationFrame(frameId);
       if (gameRef.current) {
         gameRef.current.destroy(true);
         gameRef.current = null;
@@ -115,7 +112,13 @@ export const TownEngine = () => {
       style={{ imageRendering: "pixelated" }}
     >
       {entryGate.showPreparing ? <TownEntryPreparing /> : null}
-      <div ref={gameContainerRef} />
+      <div
+        ref={gameContainerRef}
+        className={cn(
+          entryGate.shouldFadeIn && "opacity-0 transition-opacity duration-300",
+          entryGate.shouldFadeIn && engineVisible && "opacity-100",
+        )}
+      />
       {entryGate.canMountEngine ? <MovementOverlay /> : null}
     </div>
   );

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -42,6 +42,11 @@ export const TownEngine = () => {
    * true가 되기 전까지 엔진 마운트를 보류하여 캐릭터 위치 오류 방지
    */
   const { isReady, restoreStatus } = useRestorePlayerPosition();
+
+  /**
+   * restore 상태가 바뀌면 fallback gate의 파생 상태를 함께 초기화한다.
+   * useEffect 내 동기 setState 대신 React 권장 이전 값 비교 패턴을 사용한다.
+   */
   if (previousRestoreStatus !== restoreStatus) {
     setPreviousRestoreStatus(restoreStatus);
     setFallbackWaitElapsed(false);

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -9,10 +9,26 @@ import { useRestorePlayerPosition } from "@/features/movement/hooks/useRestorePl
 import { useSavePlayerPosition } from "@/features/movement/hooks/useSavePlayerPosition";
 import { TownScene } from "@/features/movement/lib/TownScene";
 import { GAME_CONFIG } from "@/features/movement/model/config";
+import {
+  FALLBACK_SPAWN_STABILIZE_MS,
+  resolveTownEntryGate,
+} from "@/features/movement/model/entryGate";
+import type { RestoreStatus } from "@/features/movement/model/types";
 import { MovementOverlay } from "@/features/movement/ui/MovementOverlay";
+import { TownEntryPreparing } from "@/features/movement/ui/TownEntryPreparing";
 import * as Phaser from "phaser";
 
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
+
+/**
+ * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
+ * 위치 복원 상태와 연동하여 게임 인스턴스의 초기화 타이밍을 제어함
+ */
+
+/**
+ * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
+ * 위치 복원 상태와 연동하여 게임 인스턴스의 초기화 타이밍을 제어함
+ */
 
 /**
  * Phaser 게임 엔진을 React 환경에 마운트하고 관리하는 엔진 컨테이너
@@ -26,12 +42,24 @@ import React, { useEffect, useRef } from "react";
 export const TownEngine = () => {
   const gameContainerRef = useRef<HTMLDivElement>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
+  const [fallbackWaitElapsed, setFallbackWaitElapsed] = useState(false);
+  const [previousRestoreStatus, setPreviousRestoreStatus] = useState<RestoreStatus>("loading");
 
   /**
    * 위치 복원 완료 여부 조회
    * true가 되기 전까지 엔진 마운트를 보류하여 캐릭터 위치 오류 방지
    */
-  const { isReady } = useRestorePlayerPosition();
+  const { isReady, restoreStatus } = useRestorePlayerPosition();
+  if (previousRestoreStatus !== restoreStatus) {
+    setPreviousRestoreStatus(restoreStatus);
+    setFallbackWaitElapsed(false);
+  }
+
+  const entryGate = resolveTownEntryGate({
+    isReady,
+    restoreStatus,
+    fallbackWaitElapsed,
+  });
 
   /**
    * 위치 복원 완료 후에만 현재 위치 저장 활성화
@@ -43,8 +71,22 @@ export const TownEngine = () => {
    */
   useMovementSync();
 
+  /**
+   * fallback spawn은 realtime presence 반영 전 잠깐 겹쳐 보일 수 있어
+   * 엔진을 즉시 표시하지 않고 짧은 준비 상태를 유지한다.
+   */
   useEffect(() => {
-    if (!isReady || !gameContainerRef.current || gameRef.current) return;
+    if (!isReady || restoreStatus !== "fallback" || fallbackWaitElapsed) return;
+
+    const timeout = setTimeout(() => {
+      setFallbackWaitElapsed(true);
+    }, FALLBACK_SPAWN_STABILIZE_MS);
+
+    return () => clearTimeout(timeout);
+  }, [fallbackWaitElapsed, isReady, restoreStatus]);
+
+  useEffect(() => {
+    if (!entryGate.canMountEngine || !gameContainerRef.current || gameRef.current) return;
 
     const config: Phaser.Types.Core.GameConfig = {
       type: Phaser.AUTO,
@@ -65,15 +107,16 @@ export const TownEngine = () => {
         gameRef.current = null;
       }
     };
-  }, [isReady]);
+  }, [entryGate.canMountEngine]);
 
   return (
     <div
       className="relative w-full h-full flex items-center justify-center bg-black overflow-hidden rounded-lg shadow-2xl border-4 border-gray-800"
       style={{ imageRendering: "pixelated" }}
     >
+      {entryGate.showPreparing ? <TownEntryPreparing /> : null}
       <div ref={gameContainerRef} />
-      <MovementOverlay />
+      {entryGate.canMountEngine ? <MovementOverlay /> : null}
     </div>
   );
 };

--- a/src/features/movement/ui/TownEntryPreparing.tsx
+++ b/src/features/movement/ui/TownEntryPreparing.tsx
@@ -1,3 +1,6 @@
+/**
+ * 위치 복원 또는 fallback spawn 안정화 중 표시하는 타운 입장 준비 화면
+ */
 export function TownEntryPreparing() {
   return (
     <section

--- a/src/features/movement/ui/TownEntryPreparing.tsx
+++ b/src/features/movement/ui/TownEntryPreparing.tsx
@@ -1,0 +1,14 @@
+export function TownEntryPreparing() {
+  return (
+    <section
+      aria-busy="true"
+      aria-live="polite"
+      className="flex h-full w-full items-center justify-center bg-black text-center text-white"
+    >
+      <div className="space-y-2 px-6">
+        <h2 className="text-lg font-semibold">입장 준비 중...</h2>
+        <p className="text-sm text-gray-300">안전한 시작 위치를 확인하고 있습니다.</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

이슈 #124 의 신규/fallback 입장자 초기 겹침 노출 문제를 UX 관점에서 완화했습니다.

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)
- fallback/신규 입장 후 겹침 완화 결과 확인
<img width="1440" height="900" alt="issue-124-incognito-after-join" src="https://github.com/user-attachments/assets/c8e3f69c-7a20-4508-89f1-1178a9af940c" />


- fade-in 중간 상태 확인
<img width="1440" height="900" alt="issue-124-fade-04-500ms" src="https://github.com/user-attachments/assets/be7a7ad6-8021-4843-bfd9-7ca11abcf223" />


- fade-in 완료 상태 확인
<img width="1440" height="900" alt="issue-124-fade-05-900ms" src="https://github.com/user-attachments/assets/6407f9e5-d5fc-4c67-a691-ce2562186e8a" />


## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
  - `restored` 사용자는 불필요한 대기/fade-in 없이 기존처럼 빠르게 입장하는지
  - `fallback` 사용자에게만 준비 UI와 fade-in이 적용되는지
  - `resolveTownEntryGate`의 분기가 `TownEngine`의 마운트/overlay 표시 조건과 잘 맞는지
  
- **함께 고민하고 싶은 부분:**
  - 이번 변경은 UX 완화책이며, 동시 입장 시 같은 spawn 후보를 선택하는 race 자체를 서버에서 제거하지는 않습니다.
  - 근본 해결이 필요하다면 서버 기반 spawn 예약, presence 초기 handshake, clientId 기반 탭/세션 구분 등을 별도 이슈로 다루는 것이 좋겠습니다.
