### PR TITLE
[bug] 빌리지 경계 왕복 시 입장/퇴장 토스트와 접속자 수가 반복 갱신되는 문제  #128

### DIFF
--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -14,6 +14,7 @@ import {
   SyncPositionPayload,
 } from "@/features/movement/model/types";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
+import { PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS } from "@/shared/constants";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 import { useUserInfo } from "@/shared/hooks/useUserInfo";
 import { getVillageChannelName } from "@/shared/lib/realtime";
@@ -38,8 +39,6 @@ import {
   createMovementSyncState,
   getVillageSetKey,
 } from "../lib/movementSyncState";
-
-const MOVEMENT_PRESENCE_VILLAGE_DEBOUNCE_MS = 1500;
 
 /**
  * 현재 village + 인접 village 범위를 기준으로 Realtime/Phaser visibility를 동기화한다.
@@ -80,7 +79,7 @@ export function useMovementSync() {
   const { userId: playerId, userNickname, selectedCharacterId } = useUserStore();
   const debouncedTrackedVillageId = useDebouncedValue(
     villageId,
-    MOVEMENT_PRESENCE_VILLAGE_DEBOUNCE_MS,
+    PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS,
   );
 
   const syncStateRef = useRef(createMovementSyncState());

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -5,6 +5,7 @@ import { VillageId, getVisibleVillages } from "@/entities/village";
 import { resolveCharacterId } from "@/features/movement/model/config";
 import {
   createPresencePayload,
+  createPresenceTrackSignature,
   createSyncPositionPayload,
 } from "@/features/movement/model/payload";
 import {
@@ -220,7 +221,7 @@ export function useMovementSync() {
         characterId: state.characterId,
       });
 
-      const payloadSignature = JSON.stringify(payload);
+      const payloadSignature = createPresenceTrackSignature(payload);
       if (retryCount === 0 && syncState.lastPresenceSignature === payloadSignature) {
         return;
       }

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -14,6 +14,7 @@ import {
   SyncPositionPayload,
 } from "@/features/movement/model/types";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
+import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 import { useUserInfo } from "@/shared/hooks/useUserInfo";
 import { getVillageChannelName } from "@/shared/lib/realtime";
 import {
@@ -37,6 +38,8 @@ import {
   createMovementSyncState,
   getVillageSetKey,
 } from "../lib/movementSyncState";
+
+const MOVEMENT_PRESENCE_VILLAGE_DEBOUNCE_MS = 1500;
 
 /**
  * 현재 village + 인접 village 범위를 기준으로 Realtime/Phaser visibility를 동기화한다.
@@ -75,6 +78,10 @@ export function useMovementSync() {
   const { data: user } = useUserInfo();
   const channelUserId = user?.id;
   const { userId: playerId, userNickname, selectedCharacterId } = useUserStore();
+  const debouncedTrackedVillageId = useDebouncedValue(
+    villageId,
+    MOVEMENT_PRESENCE_VILLAGE_DEBOUNCE_MS,
+  );
 
   const syncStateRef = useRef(createMovementSyncState());
 
@@ -466,7 +473,7 @@ export function useMovementSync() {
     if (!supabase || !channelUserId || !playerId) return;
 
     const prevTrackedVillageId = syncState.trackedVillageId;
-    if (prevTrackedVillageId && prevTrackedVillageId !== villageId) {
+    if (prevTrackedVillageId && prevTrackedVillageId !== debouncedTrackedVillageId) {
       syncState.trackRequestId += 1;
       syncState.lastPresenceSignature = "";
 
@@ -483,9 +490,17 @@ export function useMovementSync() {
       }
     }
 
-    syncState.trackedVillageId = villageId;
+    syncState.trackedVillageId = debouncedTrackedVillageId;
     void syncState.handlers.trackCurrentPresence();
-  }, [channelUserId, characterId, lastSyncedPosition, nickname, playerId, supabase, villageId]);
+  }, [
+    channelUserId,
+    characterId,
+    debouncedTrackedVillageId,
+    lastSyncedPosition,
+    nickname,
+    playerId,
+    supabase,
+  ]);
 
   useEffect(() => {
     if (!playerId || !nickname) return;

--- a/src/features/movement/model/payload.ts
+++ b/src/features/movement/model/payload.ts
@@ -35,6 +35,21 @@ export const createPresencePayload = ({
   characterId: resolveCharacterId(characterId),
 });
 
+export const createPresenceTrackSignature = ({
+  userId,
+  nickname,
+  joinedAt,
+  villageId,
+  characterId,
+}: PresenceMetadata) =>
+  JSON.stringify({
+    userId,
+    nickname,
+    joinedAt,
+    villageId,
+    characterId,
+  });
+
 export const createSyncPositionPayload = ({
   userId,
   nickname,

--- a/src/features/presence/model/presenceParticipants.ts
+++ b/src/features/presence/model/presenceParticipants.ts
@@ -1,0 +1,98 @@
+import { PresenceParticipant } from "../types";
+
+interface ResolvePresenceParticipantsParams {
+  nextParticipants: PresenceParticipant[];
+  previousParticipants: PresenceParticipant[];
+  previousUserIds: Set<string>;
+  pendingDepartureUserIds: Set<string>;
+  hasInitialized: boolean;
+  currentUserId: string;
+}
+
+interface ResolvedPresenceParticipants {
+  stableParticipants: PresenceParticipant[];
+  snapshotUserIdSet: Set<string>;
+  recoveredPendingDepartureUserIds: string[];
+  departureCandidates: PresenceParticipant[];
+  displayParticipants: PresenceParticipant[];
+  currentUserIdSet: Set<string>;
+  initialJoinParticipant?: PresenceParticipant;
+  joinToastParticipants: PresenceParticipant[];
+}
+
+export function resolvePresenceParticipants({
+  nextParticipants,
+  previousParticipants,
+  previousUserIds,
+  pendingDepartureUserIds,
+  hasInitialized,
+  currentUserId,
+}: ResolvePresenceParticipantsParams): ResolvedPresenceParticipants {
+  const previousMe = previousParticipants.find((p) => p.userId === currentUserId);
+  const hasCurrentUser = nextParticipants.some((p) => p.userId === currentUserId);
+  const stableParticipants =
+    previousMe && !hasCurrentUser ? [...nextParticipants, previousMe] : nextParticipants;
+  const snapshotUserIdSet = new Set(stableParticipants.map((p) => p.userId));
+  const recoveredPendingDepartureUserIds = Array.from(pendingDepartureUserIds).filter((userId) =>
+    snapshotUserIdSet.has(userId),
+  );
+  const activePendingDepartureUserIds = new Set(
+    Array.from(pendingDepartureUserIds).filter((userId) => !snapshotUserIdSet.has(userId)),
+  );
+
+  const departureCandidates =
+    !hasInitialized && previousUserIds.size > 0
+      ? Array.from(previousUserIds).flatMap((userId) => {
+          if (snapshotUserIdSet.has(userId) || activePendingDepartureUserIds.has(userId)) {
+            return [];
+          }
+
+          const previousParticipant = previousParticipants.find((p) => p.userId === userId);
+          return previousParticipant ? [previousParticipant] : [];
+        })
+      : [];
+
+  const participantById = new Map(stableParticipants.map((p) => [p.userId, p]));
+
+  const retainedDepartureUserIds = new Set([
+    ...activePendingDepartureUserIds,
+    ...departureCandidates.map((participant) => participant.userId),
+  ]);
+
+  retainedDepartureUserIds.forEach((userId) => {
+    const previousParticipant = previousParticipants.find((p) => p.userId === userId);
+    if (previousParticipant && !participantById.has(userId)) {
+      participantById.set(userId, previousParticipant);
+    }
+  });
+
+  const displayParticipants = Array.from(participantById.values()).sort((a, b) =>
+    a.nickname.localeCompare(b.nickname, "ko"),
+  );
+  const currentUserIdSet = new Set(displayParticipants.map((p) => p.userId));
+  const initialJoinParticipant = hasInitialized
+    ? displayParticipants.find((p) => p.userId === currentUserId)
+    : undefined;
+  const joinToastParticipants =
+    !hasInitialized && previousUserIds.size > 0
+      ? Array.from(snapshotUserIdSet).flatMap((userId) => {
+          if (previousUserIds.has(userId)) {
+            return [];
+          }
+
+          const participant = stableParticipants.find((p) => p.userId === userId);
+          return participant ? [participant] : [];
+        })
+      : [];
+
+  return {
+    stableParticipants,
+    snapshotUserIdSet,
+    recoveredPendingDepartureUserIds,
+    departureCandidates,
+    displayParticipants,
+    currentUserIdSet,
+    initialJoinParticipant,
+    joinToastParticipants,
+  };
+}

--- a/src/features/presence/model/presenceParticipants.ts
+++ b/src/features/presence/model/presenceParticipants.ts
@@ -5,7 +5,7 @@ interface ResolvePresenceParticipantsParams {
   previousParticipants: PresenceParticipant[];
   previousUserIds: Set<string>;
   pendingDepartureUserIds: Set<string>;
-  hasInitialized: boolean;
+  isAwaitingInitialJoin: boolean;
   currentUserId: string;
 }
 
@@ -25,7 +25,7 @@ export function resolvePresenceParticipants({
   previousParticipants,
   previousUserIds,
   pendingDepartureUserIds,
-  hasInitialized,
+  isAwaitingInitialJoin,
   currentUserId,
 }: ResolvePresenceParticipantsParams): ResolvedPresenceParticipants {
   const previousMe = previousParticipants.find((p) => p.userId === currentUserId);
@@ -41,7 +41,7 @@ export function resolvePresenceParticipants({
   );
 
   const departureCandidates =
-    !hasInitialized && previousUserIds.size > 0
+    !isAwaitingInitialJoin && previousUserIds.size > 0
       ? Array.from(previousUserIds).flatMap((userId) => {
           if (snapshotUserIdSet.has(userId) || activePendingDepartureUserIds.has(userId)) {
             return [];
@@ -70,11 +70,11 @@ export function resolvePresenceParticipants({
     a.nickname.localeCompare(b.nickname, "ko"),
   );
   const currentUserIdSet = new Set(displayParticipants.map((p) => p.userId));
-  const initialJoinParticipant = hasInitialized
+  const initialJoinParticipant = isAwaitingInitialJoin
     ? displayParticipants.find((p) => p.userId === currentUserId)
     : undefined;
   const joinToastParticipants =
-    !hasInitialized && previousUserIds.size > 0
+    !isAwaitingInitialJoin && previousUserIds.size > 0
       ? Array.from(snapshotUserIdSet).flatMap((userId) => {
           if (previousUserIds.has(userId)) {
             return [];

--- a/src/features/presence/model/useTownPresence.ts
+++ b/src/features/presence/model/useTownPresence.ts
@@ -172,7 +172,7 @@ export const useTownPresence = () => {
       if (channel) {
         const state = channel.presenceState();
         const mapped = mapPresenceState(state);
-        setParticipantsState(mapped, userNickname || "", userId || "");
+        setParticipantsState(mapped, userId || "");
       }
     };
 
@@ -184,7 +184,7 @@ export const useTownPresence = () => {
     return () => {
       unsubscribe();
     };
-  }, [channel, subscribeToPresence, setParticipantsState, userNickname, userId]);
+  }, [channel, subscribeToPresence, setParticipantsState, userId]);
 
   // 4. 연결 피드백 토스트
   useEffect(() => {

--- a/src/features/presence/model/useTownPresence.ts
+++ b/src/features/presence/model/useTownPresence.ts
@@ -3,6 +3,7 @@
 import { LOBBY_VILLAGE_ID, VILLAGES, VillageId } from "@/entities/village";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { useTownPresenceStore } from "@/features/presence/model/useTownPresenceStore";
+import { PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS } from "@/shared/constants";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 import { useTownChannel } from "@/shared/hooks/useTownChannel";
 import { useUserInfo } from "@/shared/hooks/useUserInfo";
@@ -13,8 +14,6 @@ import { useShallow } from "zustand/react/shallow";
 import { useEffect } from "react";
 
 import { PresenceParticipant } from "../types";
-
-const TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS = 1500;
 
 // Supabase Presence payload의 villageId를 런타임에서 검증해 내부 VillageId 타입으로 좁힌다.
 const isVillageId = (value: unknown): value is VillageId =>
@@ -58,7 +57,7 @@ const mapPresenceState = (state: RealtimePresenceState): PresenceParticipant[] =
 
 /**
  * Supabase Presence `town:main` 채널을 구독해
- * 접속 중인 사용자 목록과 연결 상태를 제공하는 훅입니다.
+ * 접속 중인 사용자 목록과 연결 상태를 제공하는 훅이다.
  */
 export const useTownPresenceView = () => {
   const participants = useTownPresenceStore((state) => state.participants);
@@ -76,7 +75,7 @@ export const useTownPresence = () => {
   const userNickname = user?.user_metadata?.nickname as string | undefined;
 
   const villageId = useMovementStore((state) => state.villageId);
-  const debouncedVillageId = useDebouncedValue(villageId, TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS);
+  const debouncedVillageId = useDebouncedValue(villageId, PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS);
 
   const {
     channel,

--- a/src/features/presence/model/useTownPresence.ts
+++ b/src/features/presence/model/useTownPresence.ts
@@ -9,13 +9,31 @@ import { PresenceStateItem, PresenceTrackPayload } from "@/shared/types/presence
 import { RealtimePresenceState } from "@supabase/supabase-js";
 import { useShallow } from "zustand/react/shallow";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { PresenceParticipant } from "../types";
+
+const TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS = 1500;
 
 // Supabase Presence payload의 villageId를 런타임에서 검증해 내부 VillageId 타입으로 좁힌다.
 const isVillageId = (value: unknown): value is VillageId =>
   typeof value === "string" && Object.hasOwn(VILLAGES, value);
+
+const useDebouncedVillageId = (villageId: VillageId) => {
+  const [debouncedVillageId, setDebouncedVillageId] = useState(villageId);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setDebouncedVillageId(villageId);
+    }, TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [villageId]);
+
+  return debouncedVillageId;
+};
 
 /**
  * Supabase Presence 상태를 PresenceParticipant 배열로 변환한다.
@@ -73,6 +91,7 @@ export const useTownPresence = () => {
   const userNickname = user?.user_metadata?.nickname as string | undefined;
 
   const villageId = useMovementStore((state) => state.villageId);
+  const debouncedVillageId = useDebouncedVillageId(villageId);
 
   const {
     channel,
@@ -115,7 +134,7 @@ export const useTownPresence = () => {
         userId,
         nickname: userNickname || "익명",
         joinedAt: localJoinedAt,
-        villageId,
+        villageId: debouncedVillageId,
         username: userNickname,
         isSpeaker,
         voiceConnected,
@@ -156,7 +175,7 @@ export const useTownPresence = () => {
     channel,
     userId,
     userNickname,
-    villageId,
+    debouncedVillageId,
     reconnect,
     localJoinedAt,
     isSpeaker,

--- a/src/features/presence/model/useTownPresence.ts
+++ b/src/features/presence/model/useTownPresence.ts
@@ -3,13 +3,14 @@
 import { LOBBY_VILLAGE_ID, VILLAGES, VillageId } from "@/entities/village";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { useTownPresenceStore } from "@/features/presence/model/useTownPresenceStore";
+import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 import { useTownChannel } from "@/shared/hooks/useTownChannel";
 import { useUserInfo } from "@/shared/hooks/useUserInfo";
 import { PresenceStateItem, PresenceTrackPayload } from "@/shared/types/presence";
 import { RealtimePresenceState } from "@supabase/supabase-js";
 import { useShallow } from "zustand/react/shallow";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { PresenceParticipant } from "../types";
 
@@ -18,22 +19,6 @@ const TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS = 1500;
 // Supabase Presence payload의 villageId를 런타임에서 검증해 내부 VillageId 타입으로 좁힌다.
 const isVillageId = (value: unknown): value is VillageId =>
   typeof value === "string" && Object.hasOwn(VILLAGES, value);
-
-const useDebouncedVillageId = (villageId: VillageId) => {
-  const [debouncedVillageId, setDebouncedVillageId] = useState(villageId);
-
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      setDebouncedVillageId(villageId);
-    }, TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS);
-
-    return () => {
-      clearTimeout(timerId);
-    };
-  }, [villageId]);
-
-  return debouncedVillageId;
-};
 
 /**
  * Supabase Presence 상태를 PresenceParticipant 배열로 변환한다.
@@ -91,7 +76,7 @@ export const useTownPresence = () => {
   const userNickname = user?.user_metadata?.nickname as string | undefined;
 
   const villageId = useMovementStore((state) => state.villageId);
-  const debouncedVillageId = useDebouncedVillageId(villageId);
+  const debouncedVillageId = useDebouncedValue(villageId, TOWN_PRESENCE_VILLAGE_DEBOUNCE_MS);
 
   const {
     channel,

--- a/src/features/presence/model/useTownPresenceStore.ts
+++ b/src/features/presence/model/useTownPresenceStore.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 
 import { groupParticipantsByVillage } from "../lib/groupByVillage";
 import { PresenceParticipant } from "../types";
+import { resolvePresenceParticipants } from "./presenceParticipants";
 
 const DEPARTURE_FALLBACK_MS = 8000;
 
@@ -81,88 +82,68 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   listeningEnabled: true,
   toggleLocalListening: null,
 
-  setParticipants: (participants, currentUserNickname, currentUserId) => {
+  setParticipants: (participants, _currentUserNickname, currentUserId) => {
     const state = get();
-    const previousMe = state.participants.find((p) => p.userId === currentUserId);
-    const hasCurrentUser = participants.some((p) => p.userId === currentUserId);
-    const stableParticipants =
-      previousMe && !hasCurrentUser ? [...participants, previousMe] : participants;
-    const snapshotUserIdSet = new Set(stableParticipants.map((p) => p.userId));
     const pendingDepartures = new Map(state.pendingDepartures);
-
-    pendingDepartures.forEach((timerId, userId) => {
-      if (snapshotUserIdSet.has(userId)) {
-        clearTimeout(timerId);
-        pendingDepartures.delete(userId);
-      }
+    const resolvedParticipants = resolvePresenceParticipants({
+      currentUserId,
+      hasInitialized: state.hasInitialized,
+      nextParticipants: participants,
+      pendingDepartureUserIds: new Set(pendingDepartures.keys()),
+      previousParticipants: state.participants,
+      previousUserIds: state.previousUserIds,
     });
 
-    const participantById = new Map(stableParticipants.map((p) => [p.userId, p]));
+    resolvedParticipants.recoveredPendingDepartureUserIds.forEach((userId) => {
+      const timerId = pendingDepartures.get(userId);
+      if (!timerId) return;
 
-    if (!state.hasInitialized && state.previousUserIds.size > 0) {
-      state.previousUserIds.forEach((userId) => {
-        if (snapshotUserIdSet.has(userId) || pendingDepartures.has(userId)) {
+      clearTimeout(timerId);
+      pendingDepartures.delete(userId);
+    });
+
+    resolvedParticipants.departureCandidates.forEach((previousParticipant) => {
+      const userId = previousParticipant.userId;
+      const timerId = setTimeout(() => {
+        const latestState = get();
+        if (!latestState.pendingDepartures.has(userId)) {
           return;
         }
 
-        const previousParticipant = state.participants.find((p) => p.userId === userId);
-        if (!previousParticipant) {
-          return;
-        }
+        const nextPendingDepartures = new Map(latestState.pendingDepartures);
+        nextPendingDepartures.delete(userId);
 
-        const timerId = setTimeout(() => {
-          const latestState = get();
-          if (!latestState.pendingDepartures.has(userId)) {
-            return;
-          }
+        const nextParticipants = latestState.participants.filter((p) => p.userId !== userId);
+        const nextUserIdSet = new Set(nextParticipants.map((p) => p.userId));
 
-          const nextPendingDepartures = new Map(latestState.pendingDepartures);
-          nextPendingDepartures.delete(userId);
+        toast(`${previousParticipant.nickname} 퇴장했습니다.`, { duration: 3000 });
 
-          const nextParticipants = latestState.participants.filter((p) => p.userId !== userId);
-          const nextUserIdSet = new Set(nextParticipants.map((p) => p.userId));
+        set({
+          participants: nextParticipants,
+          groupedParticipants: groupParticipantsByVillage(nextParticipants),
+          lastSyncedAt: new Date().toISOString(),
+          previousUserIds: nextUserIdSet,
+          pendingDepartures: nextPendingDepartures,
+        });
+      }, DEPARTURE_FALLBACK_MS);
 
-          toast(`${previousParticipant.nickname} 퇴장했습니다.`, { duration: 3000 });
-
-          set({
-            participants: nextParticipants,
-            groupedParticipants: groupParticipantsByVillage(nextParticipants),
-            lastSyncedAt: new Date().toISOString(),
-            previousUserIds: nextUserIdSet,
-            pendingDepartures: nextPendingDepartures,
-          });
-        }, DEPARTURE_FALLBACK_MS);
-
-        pendingDepartures.set(userId, timerId);
-      });
-    }
-
-    pendingDepartures.forEach((_, userId) => {
-      const previousParticipant = state.participants.find((p) => p.userId === userId);
-      if (previousParticipant && !participantById.has(userId)) {
-        participantById.set(userId, previousParticipant);
-      }
+      pendingDepartures.set(userId, timerId);
     });
 
-    const displayParticipants = Array.from(participantById.values());
-    const sortedDisplayParticipants = [...displayParticipants].sort((a, b) =>
-      a.nickname.localeCompare(b.nickname, "ko"),
+    const groupedParticipants = groupParticipantsByVillage(
+      resolvedParticipants.displayParticipants,
     );
-    const groupedParticipants = groupParticipantsByVillage(sortedDisplayParticipants);
-    const currentUserIds = sortedDisplayParticipants.map((p) => p.userId);
-    const currentUserIdSet = new Set(currentUserIds);
 
-    // 닉네임 대신 userId로 정확하게 자신을 식별 (유저 제안 사항)
-    const me = sortedDisplayParticipants.find((p) => p.userId === currentUserId);
-
-    if (state.hasInitialized && me) {
-      toast(`${me.nickname} 입장했습니다.`, { duration: 3000 });
+    if (resolvedParticipants.initialJoinParticipant) {
+      toast(`${resolvedParticipants.initialJoinParticipant.nickname} 입장했습니다.`, {
+        duration: 3000,
+      });
 
       set({
-        participants: sortedDisplayParticipants,
+        participants: resolvedParticipants.displayParticipants,
         groupedParticipants,
         lastSyncedAt: new Date().toISOString(),
-        previousUserIds: currentUserIdSet,
+        previousUserIds: resolvedParticipants.currentUserIdSet,
         pendingDepartures,
         hasInitialized: false,
       });
@@ -170,22 +151,15 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
       return;
     }
 
-    if (!state.hasInitialized && state.previousUserIds.size > 0) {
-      snapshotUserIdSet.forEach((userId) => {
-        if (!state.previousUserIds.has(userId)) {
-          const participant = stableParticipants.find((p) => p.userId === userId);
-          if (participant) {
-            toast(`${participant.nickname} 입장했습니다.`, { duration: 3000 });
-          }
-        }
-      });
-    }
+    resolvedParticipants.joinToastParticipants.forEach((participant) => {
+      toast(`${participant.nickname} 입장했습니다.`, { duration: 3000 });
+    });
 
     set({
-      participants: sortedDisplayParticipants,
+      participants: resolvedParticipants.displayParticipants,
       groupedParticipants,
       lastSyncedAt: new Date().toISOString(),
-      previousUserIds: currentUserIdSet,
+      previousUserIds: resolvedParticipants.currentUserIdSet,
       pendingDepartures,
     });
   },

--- a/src/features/presence/model/useTownPresenceStore.ts
+++ b/src/features/presence/model/useTownPresenceStore.ts
@@ -16,7 +16,7 @@ interface TownPresenceState {
   localJoinedAt: string;
   previousUserIds: Set<string>;
   pendingDepartures: Map<string, ReturnType<typeof setTimeout>>;
-  hasInitialized: boolean;
+  isAwaitingInitialJoin: boolean;
   /** 현재 유저의 음성 채널 연결 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
   voiceConnected: boolean;
   /** 현재 유저의 발표용 마이크 활성 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
@@ -37,11 +37,7 @@ interface TownPresenceState {
   /** 현재 유저의 청취 on/off를 수행하는 로컬 제어 함수 */
   toggleLocalListening: (() => Promise<void>) | null;
 
-  setParticipants: (
-    participants: PresenceParticipant[],
-    currentUserNickname: string,
-    currentUserId: string,
-  ) => void;
+  setParticipants: (participants: PresenceParticipant[], currentUserId: string) => void;
   setConnectionState: (isConnected: boolean) => void;
   /** 음성 연결 상태를 업데이트하고 presence track이 재전송되도록 한다. */
   setVoiceConnected: (voiceConnected: boolean) => void;
@@ -72,7 +68,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   localJoinedAt: new Date().toISOString(),
   previousUserIds: new Set(),
   pendingDepartures: new Map(),
-  hasInitialized: true,
+  isAwaitingInitialJoin: true,
   voiceConnected: false,
   audioEnabled: false,
   canToggleAudio: false,
@@ -82,12 +78,12 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   listeningEnabled: true,
   toggleLocalListening: null,
 
-  setParticipants: (participants, _currentUserNickname, currentUserId) => {
+  setParticipants: (participants, currentUserId) => {
     const state = get();
     const pendingDepartures = new Map(state.pendingDepartures);
     const resolvedParticipants = resolvePresenceParticipants({
       currentUserId,
-      hasInitialized: state.hasInitialized,
+      isAwaitingInitialJoin: state.isAwaitingInitialJoin,
       nextParticipants: participants,
       pendingDepartureUserIds: new Set(pendingDepartures.keys()),
       previousParticipants: state.participants,
@@ -145,7 +141,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
         lastSyncedAt: new Date().toISOString(),
         previousUserIds: resolvedParticipants.currentUserIdSet,
         pendingDepartures,
-        hasInitialized: false,
+        isAwaitingInitialJoin: false,
       });
 
       return;
@@ -210,7 +206,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
       lastSyncedAt: undefined,
       previousUserIds: new Set(),
       pendingDepartures: new Map(),
-      hasInitialized: true,
+      isAwaitingInitialJoin: true,
       voiceConnected: false,
       audioEnabled: false,
       canToggleAudio: false,

--- a/src/features/presence/model/useTownPresenceStore.ts
+++ b/src/features/presence/model/useTownPresenceStore.ts
@@ -5,6 +5,8 @@ import { create } from "zustand";
 import { groupParticipantsByVillage } from "../lib/groupByVillage";
 import { PresenceParticipant } from "../types";
 
+const DEPARTURE_FALLBACK_MS = 8000;
+
 interface TownPresenceState {
   participants: PresenceParticipant[];
   groupedParticipants: Partial<Record<VillageId, PresenceParticipant[]>>;
@@ -12,6 +14,7 @@ interface TownPresenceState {
   lastSyncedAt?: string;
   localJoinedAt: string;
   previousUserIds: Set<string>;
+  pendingDepartures: Map<string, ReturnType<typeof setTimeout>>;
   hasInitialized: boolean;
   /** 현재 유저의 음성 채널 연결 여부. presence track payload에 포함되어 다른 유저에게 공유된다. */
   voiceConnected: boolean;
@@ -67,6 +70,7 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
   lastSyncedAt: undefined,
   localJoinedAt: new Date().toISOString(),
   previousUserIds: new Set(),
+  pendingDepartures: new Map(),
   hasInitialized: true,
   voiceConnected: false,
   audioEnabled: false,
@@ -83,24 +87,83 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
     const hasCurrentUser = participants.some((p) => p.userId === currentUserId);
     const stableParticipants =
       previousMe && !hasCurrentUser ? [...participants, previousMe] : participants;
-    const sortedParticipants = [...stableParticipants].sort((a, b) =>
+    const snapshotUserIdSet = new Set(stableParticipants.map((p) => p.userId));
+    const pendingDepartures = new Map(state.pendingDepartures);
+
+    pendingDepartures.forEach((timerId, userId) => {
+      if (snapshotUserIdSet.has(userId)) {
+        clearTimeout(timerId);
+        pendingDepartures.delete(userId);
+      }
+    });
+
+    const participantById = new Map(stableParticipants.map((p) => [p.userId, p]));
+
+    if (!state.hasInitialized && state.previousUserIds.size > 0) {
+      state.previousUserIds.forEach((userId) => {
+        if (snapshotUserIdSet.has(userId) || pendingDepartures.has(userId)) {
+          return;
+        }
+
+        const previousParticipant = state.participants.find((p) => p.userId === userId);
+        if (!previousParticipant) {
+          return;
+        }
+
+        const timerId = setTimeout(() => {
+          const latestState = get();
+          if (!latestState.pendingDepartures.has(userId)) {
+            return;
+          }
+
+          const nextPendingDepartures = new Map(latestState.pendingDepartures);
+          nextPendingDepartures.delete(userId);
+
+          const nextParticipants = latestState.participants.filter((p) => p.userId !== userId);
+          const nextUserIdSet = new Set(nextParticipants.map((p) => p.userId));
+
+          toast(`${previousParticipant.nickname} 퇴장했습니다.`, { duration: 3000 });
+
+          set({
+            participants: nextParticipants,
+            groupedParticipants: groupParticipantsByVillage(nextParticipants),
+            lastSyncedAt: new Date().toISOString(),
+            previousUserIds: nextUserIdSet,
+            pendingDepartures: nextPendingDepartures,
+          });
+        }, DEPARTURE_FALLBACK_MS);
+
+        pendingDepartures.set(userId, timerId);
+      });
+    }
+
+    pendingDepartures.forEach((_, userId) => {
+      const previousParticipant = state.participants.find((p) => p.userId === userId);
+      if (previousParticipant && !participantById.has(userId)) {
+        participantById.set(userId, previousParticipant);
+      }
+    });
+
+    const displayParticipants = Array.from(participantById.values());
+    const sortedDisplayParticipants = [...displayParticipants].sort((a, b) =>
       a.nickname.localeCompare(b.nickname, "ko"),
     );
-    const groupedParticipants = groupParticipantsByVillage(sortedParticipants);
-    const currentUserIds = sortedParticipants.map((p) => p.userId);
+    const groupedParticipants = groupParticipantsByVillage(sortedDisplayParticipants);
+    const currentUserIds = sortedDisplayParticipants.map((p) => p.userId);
     const currentUserIdSet = new Set(currentUserIds);
 
     // 닉네임 대신 userId로 정확하게 자신을 식별 (유저 제안 사항)
-    const me = sortedParticipants.find((p) => p.userId === currentUserId);
+    const me = sortedDisplayParticipants.find((p) => p.userId === currentUserId);
 
     if (state.hasInitialized && me) {
       toast(`${me.nickname} 입장했습니다.`, { duration: 3000 });
 
       set({
-        participants: sortedParticipants,
+        participants: sortedDisplayParticipants,
         groupedParticipants,
         lastSyncedAt: new Date().toISOString(),
         previousUserIds: currentUserIdSet,
+        pendingDepartures,
         hasInitialized: false,
       });
 
@@ -108,30 +171,22 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
     }
 
     if (!state.hasInitialized && state.previousUserIds.size > 0) {
-      currentUserIdSet.forEach((userId) => {
+      snapshotUserIdSet.forEach((userId) => {
         if (!state.previousUserIds.has(userId)) {
-          const participant = sortedParticipants.find((p) => p.userId === userId);
+          const participant = stableParticipants.find((p) => p.userId === userId);
           if (participant) {
             toast(`${participant.nickname} 입장했습니다.`, { duration: 3000 });
-          }
-        }
-      });
-
-      state.previousUserIds.forEach((userId) => {
-        if (!currentUserIdSet.has(userId)) {
-          const previousParticipant = state.participants.find((p) => p.userId === userId);
-          if (previousParticipant) {
-            toast(`${previousParticipant.nickname} 퇴장했습니다.`, { duration: 3000 });
           }
         }
       });
     }
 
     set({
-      participants: sortedParticipants,
+      participants: sortedDisplayParticipants,
       groupedParticipants,
       lastSyncedAt: new Date().toISOString(),
       previousUserIds: currentUserIdSet,
+      pendingDepartures,
     });
   },
 
@@ -169,13 +224,18 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
    */
   setListeningEnabled: (listeningEnabled) => set({ listeningEnabled }),
 
-  reset: () =>
+  reset: () => {
+    get().pendingDepartures.forEach((timerId) => {
+      clearTimeout(timerId);
+    });
+
     set({
       participants: [],
       groupedParticipants: {},
       isConnected: false,
       lastSyncedAt: undefined,
       previousUserIds: new Set(),
+      pendingDepartures: new Map(),
       hasInitialized: true,
       voiceConnected: false,
       audioEnabled: false,
@@ -185,5 +245,6 @@ export const useTownPresenceStore = create<TownPresenceState>((set, get) => ({
       canToggleListening: false,
       listeningEnabled: true,
       toggleLocalListening: null,
-    }),
+    });
+  },
 }));

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./character";
+export * from "./presence";

--- a/src/shared/constants/presence.ts
+++ b/src/shared/constants/presence.ts
@@ -1,0 +1,5 @@
+/**
+ * 빠른 빌리지 경계 왕복 중 presence track이 과도하게 반복되지 않도록
+ * town:main과 village:* 채널에서 함께 사용하는 안정화 지연 시간이다.
+ */
+export const PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS = 1500;

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -4,3 +4,4 @@ export * from "./useUserInfo";
 export * from "./useIntersectionObserver";
 export * from "./useVisiblePageTracking";
 export * from "./useAutoResizeTextarea";
+export * from "./useDebouncedValue";

--- a/src/shared/hooks/useDebouncedValue.ts
+++ b/src/shared/hooks/useDebouncedValue.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 지정한 시간 동안 값 변경이 멈춘 뒤 마지막 값을 반영한다.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

빠르게 빌리지 경계를 왕복할 때 Supabase presence track이 과도하게 반복되면서 사용자 패널 인원수와 입장/퇴장 토스트가 흔들리던 문제를 개선했습니다.

  - `town:main`과 `village:*` presence track에 동일한 debounce 정책을 적용했습니다.
  - movement presence track signature에서 위치 좌표를 제외해 이동 중 불필요한 track 반복을 줄였습니다.
  - snapshot에서 사용자가 일시적으로 빠져도 바로 퇴장 처리하지 않고 fallback 시간 동안 패널에 유지하도
  록 했습니다.
  - 참여자 목록 계산과 입장/퇴장 판정 로직을 `resolvePresenceParticipants` 순수함수로 분리했습니다.
  - debounce 시간은 `PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS` 상수로 공유해 두 presence 채널 정책이 어긋나
  지 않도록 정리했습니다.

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

1. 두 사용자가 타운에 입장한 상태에서 한 사용자가 빠르게 빌리지 경계를 왕복하는 시나리오입니다.


https://github.com/user-attachments/assets/64af9d60-bb5b-495f-a98b-47d2a035aa79



2. 한 사용자가 타운에 입장한 뒤 새로고침하는 시나리오입니다.


https://github.com/user-attachments/assets/dfbdbf37-faef-438d-a990-53038b9ebe09




3. 한 사용자가 브라우저 컨텍스트를 종료해 실제로 타운에서 이탈하는 시나리오입니다.


https://github.com/user-attachments/assets/7b71d7de-f14c-4bb3-87d5-0dfd10a90727




## 💬 추가 전달사항

- **주의깊게 봐주길 원하는 부분:**
    - 빠른 빌리지 이동 중 실제 접속자가 유지되는 경우, 사용자 패널 인원수가 줄었다 늘지 않는지 확인 부
    탁드립니다.
    - 새로고침은 일시적인 presence 누락으로 보고 퇴장 토스트를 띄우지 않는 정책으로 처리했습니다.
    - 실제 브라우저 종료처럼 복구되지 않는 경우에는 fallback 이후 퇴장 토스트와 패널 제거가 발생합니
    다.

- **함께 고민하고 싶은 부분:**
    - 현재 fallback 시간은 8초입니다. 네트워크 지연과 UX 사이에서 적절한 값인지 함께 봐주시면 좋겠습니
    다.
    - `useDebouncedValue`는 이번 작업에서 shared hook으로 분리했는데, 기존 코드에도 비슷한 debounce 로
    직을 사용하는 부분이 보여 별도 이슈로 분리해 정리하는 것이 좋을 것 같습니다.

  - **기타 참고사항:**
    - 검증 결과 빠른 빌리지 이동과 새로고침 시 패널 인원수 감소 및 퇴장 토스트가 발생하지 않았습니다.
    - 브라우저 종료 시에는 fallback 이후 인원수가 1명 감소하고 퇴장 토스트가 1회 표시되는 것을 확인했
    습니다.