### PR TITLE
[bug] 채팅 입력 중 WASD 이동 및 연속 채팅 끊김 문제 해결

### DIFF
--- a/src/features/chat/ui/MessageField.tsx
+++ b/src/features/chat/ui/MessageField.tsx
@@ -88,13 +88,21 @@ export default function MessageField({
       setMessage(trimmed);
     }
 
-    textareaRef.current?.blur();
+    // 연속 채팅이 가능하도록 전송 후에도 포커스를 유지한다.
+    // 이동키 캡처 제어는 TownScene.update()에서 activeElement를 매 프레임 확인해 처리하므로
+    // 여기서 blur를 호출할 필요가 없다.
+    textareaRef.current?.focus();
   };
 
-  const handleEnterKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       sendMessage();
+      return;
+    }
+
+    if (e.key === "Escape") {
+      textareaRef.current?.blur();
     }
   };
 
@@ -133,7 +141,7 @@ export default function MessageField({
             ref={textareaRef}
             value={message}
             onChange={updateMessage}
-            onKeyDown={handleEnterKey}
+            onKeyDown={handleKeyDown}
             placeholder={PLACEHOLDER_TEXT}
             rows={1}
             disabled={isPrivateChannel}

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -12,6 +12,7 @@ import {
   getCharacterConfig,
   useMovementStore,
 } from "@/features/movement";
+import { isEditableElementFocused } from "@/features/movement/lib/domFocus";
 import { RemotePlayer } from "@/features/movement/model/types";
 import * as Phaser from "phaser";
 
@@ -41,6 +42,7 @@ export class TownScene extends Phaser.Scene {
   private localUserId: string = "";
   private debugText!: Phaser.GameObjects.Text;
   private localCharacterId: CharacterId = "p-boy";
+  private wasInputFocused = false;
 
   constructor() {
     super("TownScene");
@@ -357,25 +359,19 @@ export class TownScene extends Phaser.Scene {
     // 2. 로컬 플레이어 입력 처리
     const speed = 4;
 
-    // 입력 필드 포커스 시:
-    // 1. removeCapture로 Phaser의 키 캡처를 해제하여 브라우저가 키 이벤트를 처리하도록 함
-    // 2. 캐릭터 이동 로직 실행 방지
-    const activeElement = document.activeElement;
-    const isInputFocused =
-      activeElement instanceof HTMLInputElement ||
-      activeElement instanceof HTMLTextAreaElement ||
-      (activeElement as HTMLElement | null)?.isContentEditable === true;
+    const isInputFocused = isEditableElementFocused();
 
-    if (this.input.keyboard) {
+    // 포커스 상태가 실제로 바뀐 프레임에만 캡처를 토글 (매 프레임 addCapture/removeCapture 호출 방지)
+    if (this.input.keyboard && isInputFocused !== this.wasInputFocused) {
       if (isInputFocused) {
-        // 채팅창 포커스 시: 키 캡처 해제하여 브라우저가 키 입력을 처리하도록 함
         this.input.keyboard.removeCapture(CAPTURED_KEYS);
-        return;
       } else {
-        // 게임 플레이 시: 키 캡처 활성화하여 Phaser가 키 입력을 독점하도록 함
         this.input.keyboard.addCapture(CAPTURED_KEYS);
       }
+      this.wasInputFocused = isInputFocused;
     }
+
+    if (isInputFocused) return;
 
     let dx = 0;
     let dy = 0;

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -362,7 +362,9 @@ export class TownScene extends Phaser.Scene {
     // 2. 캐릭터 이동 로직 실행 방지
     const activeElement = document.activeElement;
     const isInputFocused =
-      activeElement && (activeElement.tagName === "INPUT" || activeElement.tagName === "TEXTAREA");
+      activeElement instanceof HTMLInputElement ||
+      activeElement instanceof HTMLTextAreaElement ||
+      (activeElement as HTMLElement | null)?.isContentEditable === true;
 
     if (this.input.keyboard) {
       if (isInputFocused) {

--- a/src/features/movement/lib/domFocus.ts
+++ b/src/features/movement/lib/domFocus.ts
@@ -1,0 +1,29 @@
+function getFocusedEditableElement(): HTMLElement | null {
+  const activeElement = document.activeElement;
+
+  if (
+    activeElement instanceof HTMLInputElement ||
+    activeElement instanceof HTMLTextAreaElement ||
+    (activeElement as HTMLElement | null)?.isContentEditable === true
+  ) {
+    return activeElement as HTMLElement;
+  }
+
+  return null;
+}
+
+/**
+ * document.activeElement가 텍스트 입력 가능한 요소(input, textarea, contentEditable)인지 판별
+ * 채팅 입력 중 WASD 캡처 방지, 맵 클릭 시 입력창 blur 처리 등에서 공통으로 사용
+ */
+export function isEditableElementFocused(): boolean {
+  return getFocusedEditableElement() !== null;
+}
+
+/**
+ * 현재 포커스된 요소가 텍스트 입력 요소이면 blur 처리
+ * 맵 클릭 시 채팅 입력창에서 빠져나오는 용도로 사용
+ */
+export function blurActiveEditableElement(): void {
+  getFocusedEditableElement()?.blur();
+}

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -5,6 +5,7 @@ import { useRestorePlayerPosition } from "@/features/movement/hooks/useRestorePl
 import { useSavePlayerPosition } from "@/features/movement/hooks/useSavePlayerPosition";
 import { useTownMapLoader } from "@/features/movement/hooks/useTownMapLoader";
 import { TownScene } from "@/features/movement/lib/TownScene";
+import { blurActiveEditableElement } from "@/features/movement/lib/domFocus";
 import { GAME_CONFIG } from "@/features/movement/model/config";
 import {
   FALLBACK_SPAWN_STABILIZE_MS,
@@ -94,23 +95,6 @@ export const TownEngine = () => {
     return () => clearTimeout(timeout);
   }, [fallbackWaitElapsed, isTownReady, restoreStatus]);
 
-  /**
-   * 맵(Phaser 캔버스) 클릭 시 채팅 입력창 포커스 해제
-   * Phaser가 캔버스 mousedown에서 preventDefault를 호출해 브라우저의 기본 blur 동작까지
-   * 함께 막히므로, 여기서 activeElement를 직접 확인해 명시적으로 blur 처리한다.
-   */
-  const handleMapPointerDown = () => {
-    const activeElement = document.activeElement;
-    const isTyping =
-      activeElement instanceof HTMLInputElement ||
-      activeElement instanceof HTMLTextAreaElement ||
-      (activeElement as HTMLElement | null)?.isContentEditable === true;
-
-    if (isTyping) {
-      (activeElement as HTMLElement).blur();
-    }
-  };
-
   useEffect(() => {
     if (!entryGate.canMountEngine || !gameContainerRef.current || gameRef.current) return;
 
@@ -153,9 +137,11 @@ export const TownEngine = () => {
       ) : entryGate.showPreparing ? (
         <TownEntryPreparing />
       ) : null}
+      {/* Phaser가 캔버스 mousedown에서 preventDefault를 호출해 브라우저의 기본 blur 동작까지
+          막으므로, 맵 클릭 시 채팅 입력창에서 명시적으로 빠져나오도록 처리 */}
       <div
         ref={gameContainerRef}
-        onPointerDown={handleMapPointerDown}
+        onPointerDown={blurActiveEditableElement}
         className={cn(
           "h-full w-full",
           !entryGate.canMountEngine && "pointer-events-none opacity-0",

--- a/src/features/movement/ui/TownEngine.tsx
+++ b/src/features/movement/ui/TownEngine.tsx
@@ -94,6 +94,23 @@ export const TownEngine = () => {
     return () => clearTimeout(timeout);
   }, [fallbackWaitElapsed, isTownReady, restoreStatus]);
 
+  /**
+   * 맵(Phaser 캔버스) 클릭 시 채팅 입력창 포커스 해제
+   * Phaser가 캔버스 mousedown에서 preventDefault를 호출해 브라우저의 기본 blur 동작까지
+   * 함께 막히므로, 여기서 activeElement를 직접 확인해 명시적으로 blur 처리한다.
+   */
+  const handleMapPointerDown = () => {
+    const activeElement = document.activeElement;
+    const isTyping =
+      activeElement instanceof HTMLInputElement ||
+      activeElement instanceof HTMLTextAreaElement ||
+      (activeElement as HTMLElement | null)?.isContentEditable === true;
+
+    if (isTyping) {
+      (activeElement as HTMLElement).blur();
+    }
+  };
+
   useEffect(() => {
     if (!entryGate.canMountEngine || !gameContainerRef.current || gameRef.current) return;
 
@@ -138,6 +155,7 @@ export const TownEngine = () => {
       ) : null}
       <div
         ref={gameContainerRef}
+        onPointerDown={handleMapPointerDown}
         className={cn(
           "h-full w-full",
           !entryGate.canMountEngine && "pointer-events-none opacity-0",


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
WASD를 이동 키로 쓰는 게임에서, 채팅 입력창에 `w/a/s/d`를 입력하면 캐릭터가 같이 움직이던 문제와, 이를 막는 과정에서 메시지 전송 후 입력창 포커스가 풀려 연속 채팅이 끊기던 문제를 함께 해결했습니다.

- 채팅 메시지 전송 후 `textarea`를 blur하던 로직을 제거하고 포커스를 유지하도록 변경 → Enter로 연속 전송 가능
- `Escape` 키를 눌렀을 때만 명시적으로 채팅 입력 포커스를 해제하도록 추가
- 이동 입력 처리 로직(`TownScene.update()`)이 `document.activeElement`를 확인해 input/textarea/contentEditable에 포커스가 있으면 이동을 무시하도록 판별 조건 보강
- Phaser 캔버스 클릭 시 채팅 입력창 포커스가 자동으로 풀리지 않는 문제 대응 (`TownEngine`에 pointerdown 핸들러 추가)
- 위 포커스 판별 로직이 `TownScene`, `TownEngine` 두 곳에 중복되어 있어 `domFocus.ts` 공용 유틸로 분리
- 게임 루프(`update()`, ~60fps)가 포커스 상태 변화와 무관하게 매 프레임 Phaser 키 캡처를 토글하던 부분을, 상태가 실제로 바뀐 프레임에만 실행하도록 최적화



## 🔧 변경 유형
- [ ] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제



## 📸 스크린샷 (선택 사항)
https://github.com/user-attachments/assets/c194754e-5c9e-4f8a-9347-4c2b9e80d948



## 💬 추가 전달사항
- **주의깊게 봐주길 원하는 부분:** `TownScene.update()`의 `wasInputFocused` 기반 edge-triggered 캡처 토글 로직이 기존 동작(포커스 시 이동 즉시 차단)을 그대로 유지하는지
