### PR TITLE
[feature] 다른 사용자에게 캐릭터 액션 상태 동기화  #147

### DIFF
--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -59,6 +59,7 @@ export function useMovementSync(enabled = true) {
     removeRemotePlayer,
     removeRemotePlayersOutsideVillages,
     lastSyncedPosition,
+    localActionState,
   } = useMovementStore(
     useShallow((state) => ({
       villageId: state.villageId,
@@ -71,6 +72,7 @@ export function useMovementSync(enabled = true) {
       removeRemotePlayer: state.removeRemotePlayer,
       removeRemotePlayersOutsideVillages: state.removeRemotePlayersOutsideVillages,
       lastSyncedPosition: state.lastSyncedPosition,
+      localActionState: state.localActionState,
     })),
   );
 
@@ -225,6 +227,7 @@ export function useMovementSync(enabled = true) {
         villageId: currentTrackedVillageId,
         position: state.lastSyncedPosition,
         characterId: state.characterId,
+        actionState: state.localActionState,
       });
 
       const payloadSignature = createPresenceTrackSignature(payload);
@@ -509,6 +512,7 @@ export function useMovementSync(enabled = true) {
     debouncedTrackedVillageId,
     enabled,
     lastSyncedPosition,
+    localActionState,
     nickname,
     playerId,
     supabase,
@@ -535,6 +539,7 @@ export function useMovementSync(enabled = true) {
           characterId,
           position: lastSyncedPosition,
           villageId,
+          actionState: localActionState,
         }),
       })
       .then((res) => {
@@ -542,7 +547,7 @@ export function useMovementSync(enabled = true) {
           console.warn("[useMovementSync] Broadcast failed (send error)");
         }
       });
-  }, [characterId, enabled, lastSyncedPosition, nickname, playerId, villageId]);
+  }, [characterId, enabled, lastSyncedPosition, localActionState, nickname, playerId, villageId]);
 
   useEffect(() => {
     const syncState = syncStateRef.current;

--- a/src/features/movement/index.ts
+++ b/src/features/movement/index.ts
@@ -25,11 +25,13 @@ export {
   getCharacterActionConfig,
   getLocalActionAnimationKey,
   getNextSyncedActionState,
+  resolveRemoteActionState,
   resolveLocalActionInput,
 } from "./model/actionAnimation";
 export type {
   LocalActionId,
   LocalActionInputId,
   LocalActionInputResult,
+  RemoteActionStateResult,
 } from "./model/actionAnimation";
 export type { SyncedActionState } from "./model/types";

--- a/src/features/movement/index.ts
+++ b/src/features/movement/index.ts
@@ -24,6 +24,7 @@ export {
   getActionFrameNumbers,
   getCharacterActionConfig,
   getLocalActionAnimationKey,
+  getNextSyncedActionState,
   resolveLocalActionInput,
 } from "./model/actionAnimation";
 export type {
@@ -31,3 +32,4 @@ export type {
   LocalActionInputId,
   LocalActionInputResult,
 } from "./model/actionAnimation";
+export type { SyncedActionState } from "./model/types";

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -616,6 +616,7 @@ export class TownScene extends Phaser.Scene {
     this.player.setScale(actionScale);
     this.player.setOrigin(0.5, actionConfig.originY + action.originYOffset);
     this.player.setFlipX(false);
+    useMovementStore.getState().startLocalAction(actionId);
     this.player.anims.play(animationKey);
   }
 
@@ -623,6 +624,7 @@ export class TownScene extends Phaser.Scene {
     if (!this.player || !this.player.active || !this.activeLocalActionId) return;
 
     this.activeLocalActionId = null;
+    useMovementStore.getState().stopLocalAction();
     const nextCharacterConfig = getCharacterConfig(this.localCharacterId);
     this.applyCharacterConfig(this.player, nextCharacterConfig);
     this.player.anims.stop();

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -25,6 +25,7 @@ import {
   getCharacterConfig,
   getLocalActionAnimationKey,
   resolveLocalActionInput,
+  resolveRemoteActionState,
   useMovementStore,
 } from "@/features/movement";
 import {
@@ -66,6 +67,8 @@ export class TownScene extends Phaser.Scene {
   private remotePlayerSprites: Map<string, Phaser.GameObjects.Sprite> = new Map();
   private remotePlayerNames: Map<string, Phaser.GameObjects.Text> = new Map();
   private remotePlayerTargets: Map<string, { x: number; y: number }> = new Map();
+  private remotePlayerActionSequences: Map<string, number> = new Map();
+  private activeRemoteActions: Map<string, LocalActionId> = new Map();
   private playerNameLabel!: Phaser.GameObjects.Text;
   private localUserId: string = "";
   private debugText!: Phaser.GameObjects.Text;
@@ -329,6 +332,8 @@ export class TownScene extends Phaser.Scene {
         this.remotePlayerSprites.delete(userId);
         this.remotePlayerNames.delete(userId);
         this.remotePlayerTargets.delete(userId);
+        this.remotePlayerActionSequences.delete(userId);
+        this.activeRemoteActions.delete(userId);
       }
     });
 
@@ -367,7 +372,10 @@ export class TownScene extends Phaser.Scene {
         this.remotePlayerNames.set(userId, nameLabel);
         this.syncCharacterDepth(sprite, nameLabel);
       } else {
-        if (sprite.texture.key !== characterConfig.assetKey) {
+        if (
+          sprite.texture.key !== characterConfig.assetKey &&
+          !this.activeRemoteActions.has(userId)
+        ) {
           this.applyCharacterConfig(sprite, characterConfig);
         }
 
@@ -381,6 +389,8 @@ export class TownScene extends Phaser.Scene {
       if (data.position) {
         this.remotePlayerTargets.set(userId, { x: data.position.x, y: data.position.y });
       }
+
+      this.applyRemoteActionState(userId, sprite, data);
     });
   };
 
@@ -409,9 +419,24 @@ export class TownScene extends Phaser.Scene {
         // 리모트 플레이어 애니메이션 처리
         const diffX = sprite.x - prevX;
         const diffY = sprite.y - prevY;
+        const activeRemoteAction = this.activeRemoteActions.get(userId);
 
         // 약간의 움직임은 무시 (보간으로 인한 미세 진동)
-        if (Math.abs(diffX) > 0.5 || Math.abs(diffY) > 0.5) {
+        const isRemoteMoving = Math.abs(diffX) > 0.5 || Math.abs(diffY) > 0.5;
+
+        if (
+          activeRemoteAction &&
+          LOCAL_ACTION_ANIMATIONS[activeRemoteAction].repeat === 0 &&
+          !sprite.anims.isPlaying
+        ) {
+          this.stopRemoteAction(userId, sprite);
+        } else if (activeRemoteAction && isRemoteMoving) {
+          this.stopRemoteAction(userId, sprite);
+        }
+
+        if (this.activeRemoteActions.has(userId)) {
+          // 액션 재생 중에는 기존 걷기/정지 애니메이션이 action atlas를 덮어쓰지 않게 유지한다.
+        } else if (isRemoteMoving) {
           if (Math.abs(diffX) > Math.abs(diffY)) {
             if (diffX < 0) {
               sprite.setFlipX(false);
@@ -629,6 +654,60 @@ export class TownScene extends Phaser.Scene {
     this.applyCharacterConfig(this.player, nextCharacterConfig);
     this.player.anims.stop();
     this.player.setFrame(0);
+  }
+
+  private applyRemoteActionState(
+    userId: string,
+    sprite: Phaser.GameObjects.Sprite,
+    remotePlayer: RemotePlayer,
+  ) {
+    const actionResult = resolveRemoteActionState(
+      this.remotePlayerActionSequences.get(userId) ?? null,
+      remotePlayer.actionState,
+    );
+
+    if (actionResult.type === "none") return;
+
+    if (actionResult.type === "stop") {
+      this.stopRemoteAction(userId, sprite);
+      return;
+    }
+
+    const characterConfig = getCharacterConfig(remotePlayer.characterId);
+    const actionConfig = getCharacterActionConfig(remotePlayer.characterId);
+    const action = LOCAL_ACTION_ANIMATIONS[actionResult.actionId];
+    const actionScale = characterConfig.frameHeight / actionConfig.visibleHeight;
+    const animationKey = getLocalActionAnimationKey(
+      remotePlayer.characterId,
+      actionResult.actionId,
+    );
+
+    if (!this.anims.exists(animationKey)) {
+      this.stopRemoteAction(userId, sprite);
+      return;
+    }
+
+    sprite.anims.stop();
+    sprite.setTexture(actionConfig.assetKey, getActionFrameNumbers(actionResult.actionId)[0]);
+    sprite.setScale(actionScale);
+    sprite.setOrigin(0.5, actionConfig.originY + action.originYOffset);
+    sprite.setFlipX(false);
+    sprite.anims.play(animationKey);
+
+    this.remotePlayerActionSequences.set(userId, actionResult.sequence);
+    this.activeRemoteActions.set(userId, actionResult.actionId);
+  }
+
+  private stopRemoteAction(userId: string, sprite: Phaser.GameObjects.Sprite) {
+    if (!this.activeRemoteActions.has(userId)) return;
+
+    const remotePlayer = useMovementStore.getState().remotePlayers[userId];
+    const characterConfig = getCharacterConfig(remotePlayer?.characterId);
+
+    this.activeRemoteActions.delete(userId);
+    this.applyCharacterConfig(sprite, characterConfig);
+    sprite.anims.stop();
+    sprite.setFrame(0);
   }
 
   private renderImageLayer(imageLayer: MapImageLayer, assetKey: string, depth: number) {

--- a/src/features/movement/model/actionAnimation.ts
+++ b/src/features/movement/model/actionAnimation.ts
@@ -48,6 +48,11 @@ export type LocalActionInputResult =
   | { type: "stop" }
   | { type: "play"; actionId: LocalActionId };
 
+export type RemoteActionStateResult =
+  | { type: "none" }
+  | { type: "stop" }
+  | { type: "play"; actionId: LocalActionId; sequence: number };
+
 export function getCharacterActionConfig(characterId: CharacterId): CharacterActionConfig {
   return CHARACTER_ACTION_CONFIGS[characterId];
 }
@@ -76,6 +81,25 @@ export function getNextSyncedActionState(
   return {
     actionId,
     sequence: (currentActionState?.sequence ?? 0) + 1,
+  };
+}
+
+export function resolveRemoteActionState(
+  lastHandledSequence: number | null,
+  actionState: SyncedActionState,
+): RemoteActionStateResult {
+  if (!actionState) {
+    return { type: "stop" };
+  }
+
+  if (lastHandledSequence !== null && actionState.sequence <= lastHandledSequence) {
+    return { type: "none" };
+  }
+
+  return {
+    type: "play",
+    actionId: actionState.actionId,
+    sequence: actionState.sequence,
   };
 }
 

--- a/src/features/movement/model/actionAnimation.ts
+++ b/src/features/movement/model/actionAnimation.ts
@@ -1,3 +1,4 @@
+import type { SyncedActionState } from "@/features/movement/model/types";
 import { CHARACTER_ACTION_CONFIGS } from "@/shared/constants";
 import type { CharacterActionConfig, CharacterId } from "@/shared/types";
 
@@ -66,6 +67,16 @@ export function getActionFrameNumbers(actionId: LocalActionId): number[] {
   const startFrame = action.row * LOCAL_ACTION_ATLAS_COLUMNS;
 
   return Array.from({ length: action.frames }, (_, index) => startFrame + index);
+}
+
+export function getNextSyncedActionState(
+  currentActionState: SyncedActionState,
+  actionId: LocalActionId,
+): SyncedActionState {
+  return {
+    actionId,
+    sequence: (currentActionState?.sequence ?? 0) + 1,
+  };
 }
 
 /**

--- a/src/features/movement/model/actionAnimation.ts
+++ b/src/features/movement/model/actionAnimation.ts
@@ -1,4 +1,4 @@
-import type { SyncedActionState } from "@/features/movement/model/types";
+import type { ActiveSyncedActionState, SyncedActionState } from "@/features/movement/model/types";
 import { CHARACTER_ACTION_CONFIGS } from "@/shared/constants";
 import type { CharacterActionConfig, CharacterId } from "@/shared/types";
 
@@ -77,7 +77,7 @@ export function getActionFrameNumbers(actionId: LocalActionId): number[] {
 export function getNextSyncedActionState(
   currentActionState: SyncedActionState,
   actionId: LocalActionId,
-): SyncedActionState {
+): ActiveSyncedActionState {
   return {
     actionId,
     sequence: (currentActionState?.sequence ?? 0) + 1,

--- a/src/features/movement/model/payload.ts
+++ b/src/features/movement/model/payload.ts
@@ -1,6 +1,11 @@
 import { VillageId } from "@/entities/village";
 import { resolveCharacterId } from "@/features/movement/model/config";
-import { Position, PresenceMetadata, SyncPositionPayload } from "@/features/movement/model/types";
+import {
+  Position,
+  PresenceMetadata,
+  SyncPositionPayload,
+  SyncedActionState,
+} from "@/features/movement/model/types";
 
 interface CreatePresencePayloadParams {
   userId: string;
@@ -9,6 +14,7 @@ interface CreatePresencePayloadParams {
   villageId: VillageId;
   position: Position;
   characterId?: string | null;
+  actionState?: SyncedActionState;
 }
 
 interface CreateSyncPositionPayloadParams {
@@ -17,6 +23,7 @@ interface CreateSyncPositionPayloadParams {
   villageId: VillageId;
   position: Position;
   characterId?: string | null;
+  actionState?: SyncedActionState;
 }
 
 export const createPresencePayload = ({
@@ -26,6 +33,7 @@ export const createPresencePayload = ({
   villageId,
   position,
   characterId,
+  actionState = null,
 }: CreatePresencePayloadParams): PresenceMetadata => ({
   userId,
   nickname,
@@ -33,6 +41,7 @@ export const createPresencePayload = ({
   villageId,
   position,
   characterId: resolveCharacterId(characterId),
+  actionState,
 });
 
 export const createPresenceTrackSignature = ({
@@ -41,6 +50,7 @@ export const createPresenceTrackSignature = ({
   joinedAt,
   villageId,
   characterId,
+  actionState,
 }: PresenceMetadata) =>
   JSON.stringify({
     userId,
@@ -48,6 +58,7 @@ export const createPresenceTrackSignature = ({
     joinedAt,
     villageId,
     characterId,
+    actionState,
   });
 
 export const createSyncPositionPayload = ({
@@ -56,10 +67,12 @@ export const createSyncPositionPayload = ({
   villageId,
   position,
   characterId,
+  actionState = null,
 }: CreateSyncPositionPayloadParams): SyncPositionPayload => ({
   userId,
   nickname,
   villageId,
   position,
   characterId: resolveCharacterId(characterId),
+  actionState,
 });

--- a/src/features/movement/model/types.ts
+++ b/src/features/movement/model/types.ts
@@ -36,10 +36,12 @@ export interface RemotePlayer {
   lastUpdatedAt: number;
 }
 
-export type SyncedActionState = {
+export type ActiveSyncedActionState = {
   actionId: LocalActionId;
   sequence: number;
-} | null;
+};
+
+export type SyncedActionState = ActiveSyncedActionState | null;
 
 /**
  * Presence 메타데이터 구조 (RemotePlayer와 호환)

--- a/src/features/movement/model/types.ts
+++ b/src/features/movement/model/types.ts
@@ -1,4 +1,5 @@
 import { VillageId } from "@/entities/village";
+import type { LocalActionId } from "@/features/movement/model/actionAnimation";
 import { CharacterId } from "@/features/movement/model/config";
 
 export const MOVEMENT_EVENT_TYPES = {
@@ -21,6 +22,7 @@ export interface MovementState {
   nickname: string;
   userId: string;
   characterId: CharacterId;
+  localActionState: SyncedActionState;
   remotePlayers: Record<string, RemotePlayer>;
 }
 
@@ -30,8 +32,14 @@ export interface RemotePlayer {
   characterId: CharacterId;
   position: Position;
   villageId: VillageId;
+  actionState: SyncedActionState;
   lastUpdatedAt: number;
 }
+
+export type SyncedActionState = {
+  actionId: LocalActionId;
+  sequence: number;
+} | null;
 
 /**
  * Presence 메타데이터 구조 (RemotePlayer와 호환)
@@ -42,6 +50,7 @@ export interface PresenceMetadata {
   characterId: CharacterId;
   position: Position;
   villageId: VillageId;
+  actionState: SyncedActionState;
   joinedAt: string;
 }
 
@@ -54,6 +63,7 @@ export interface SyncPositionPayload {
   characterId: CharacterId;
   position: Position;
   villageId: VillageId;
+  actionState: SyncedActionState;
 }
 
 export interface SyncLeavePayload {

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -49,6 +49,9 @@ export const useMovementStore = create<MovementStore>()(
     const FLUSH_INTERVAL = 100;
     let isSyncing = false;
     let flushTimeout: ReturnType<typeof setTimeout> | null = null;
+    /**
+     * localActionState가 null로 초기화되어도 다음 액션 sequence가 증가하도록 별도로 보관한다.
+     */
     let localActionSequence = 0;
 
     const createJitter = (): Position => ({

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -1,6 +1,7 @@
 import { LOBBY_VILLAGE_ID, VillageId } from "@/entities/village";
 import type { MapLoader } from "@/entities/village";
 import { findSafeSpawnPosition, validateMovement } from "@/features/movement/lib/validateMovement";
+import { LocalActionId, getNextSyncedActionState } from "@/features/movement/model/actionAnimation";
 import {
   CharacterId,
   DEFAULT_CHARACTER_ID,
@@ -26,6 +27,8 @@ interface MovementStore extends MovementState {
   setVillage: (villageId: VillageId) => void;
   initializePosition: (position: Position, villageId: VillageId) => void;
   warp: (position: Position, villageId: VillageId) => void;
+  startLocalAction: (actionId: LocalActionId) => void;
+  stopLocalAction: () => void;
   updatePosition: (delta: Position) => void;
   updateRemotePlayer: (player: RemotePlayer) => void;
   // 특정 remote player 1명 제거
@@ -60,6 +63,7 @@ export const useMovementStore = create<MovementStore>()(
       nickname: "익명",
       userId: "",
       characterId: DEFAULT_CHARACTER_ID,
+      localActionState: null,
       lastSyncedPosition: initialJitter,
       lastSyncedVillageId: LOBBY_VILLAGE_ID,
       remotePlayers: {},
@@ -74,6 +78,11 @@ export const useMovementStore = create<MovementStore>()(
       setMapLoader: (mapLoader) => set({ mapLoader }),
       setPosition: (position) => set({ position, lastSyncedPosition: position }),
       setVillage: (villageId) => set({ villageId, lastSyncedVillageId: villageId }),
+      startLocalAction: (actionId) =>
+        set((state) => ({
+          localActionState: getNextSyncedActionState(state.localActionState, actionId),
+        })),
+      stopLocalAction: () => set({ localActionState: null }),
       initializePosition: (position, villageId) => {
         const { mapLoader, remotePlayers } = get();
         const safePos = findSafeSpawnPosition(position, remotePlayers, villageId, mapLoader);
@@ -264,6 +273,7 @@ export const useMovementStore = create<MovementStore>()(
           nickname: "익명",
           userId: "",
           characterId: DEFAULT_CHARACTER_ID,
+          localActionState: null,
           lastSyncedPosition: newJitter,
           lastSyncedVillageId: LOBBY_VILLAGE_ID,
           remotePlayers: {},

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -49,6 +49,7 @@ export const useMovementStore = create<MovementStore>()(
     const FLUSH_INTERVAL = 100;
     let isSyncing = false;
     let flushTimeout: ReturnType<typeof setTimeout> | null = null;
+    let localActionSequence = 0;
 
     const createJitter = (): Position => ({
       x: INITIAL_POSITION.x + (Math.random() - 0.5) * 60,
@@ -79,9 +80,17 @@ export const useMovementStore = create<MovementStore>()(
       setPosition: (position) => set({ position, lastSyncedPosition: position }),
       setVillage: (villageId) => set({ villageId, lastSyncedVillageId: villageId }),
       startLocalAction: (actionId) =>
-        set((state) => ({
-          localActionState: getNextSyncedActionState(state.localActionState, actionId),
-        })),
+        set(() => {
+          const nextActionState = getNextSyncedActionState(
+            { actionId, sequence: localActionSequence },
+            actionId,
+          );
+          localActionSequence = nextActionState.sequence;
+
+          return {
+            localActionState: nextActionState,
+          };
+        }),
       stopLocalAction: () => set({ localActionState: null }),
       initializePosition: (position, villageId) => {
         const { mapLoader, remotePlayers } = get();
@@ -267,6 +276,7 @@ export const useMovementStore = create<MovementStore>()(
       },
       reset: () => {
         const newJitter = createJitter();
+        localActionSequence = 0;
         set({
           position: newJitter,
           villageId: LOBBY_VILLAGE_ID,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

이슈 #147 작업으로, 로컬에서만 보이던 캐릭터 액션 상태를 다른 사용자 화면에서도 보이도록 동기화했습니다.

  - `presence` / `broadcast` payload에 `actionState`를 추가했습니다.
  - 로컬 액션 시작/종료 시 `localActionState`를 갱신하도록 처리했습니다.
  - 원격 사용자 렌더링 시 `actionState`를 기준으로 `happy`, `dance`, `sit` 액션을 재
  생하도록 추가했습니다.
  - 액션 sequence를 기준으로 이미 처리한 원격 액션은 중복 재생하지 않도록 했습니다.
  - 액션 종료 후 다시 액션을 실행해도 sequence가 이어지도록 별도 값을 보관했습니다.

  Closes #147

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/11cbb4c3-fe3b-46e5-b015-e3299eb2d4ae



## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
  - `presence`와 `broadcast` payload에 추가한 `actionState` 구조가 이후 확장에도 괜
      찮을지 확인 부탁드립니다.
  - 원격 액션 재생 시 sequence 기준으로 중복 재생을 막는 방식이 적절한지 봐주시면 좋겠습니다.
- **함께 고민하고 싶은 부분:**
  - 현재는 액션 상태만 동기화하며, 액션 입력 시점의 방향이나 세부 프레임까지는 동기화하지 않았습니다.
  -  추후 액션 종류가 늘어나면 `TownScene` 안의 로컬/원격 액션 재생 및 중단 로직을 별도 controller로 분리하는 것도 고려할 수 있을 것 같습니다.
