### PR TITLE
[feature] 모바일 기기 접속 제한 기능 추가  #140

### DIFF
--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MobileAccessBlockedNotice, useMobileDeviceAccess } from "@/features/deviceAccess";
 import { resolveCharacterId } from "@/features/movement/model/config";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { useTownPanelToggleStore } from "@/features/panelToggle";
@@ -25,6 +26,24 @@ const TownEngine = dynamic(
 );
 
 export default function TownPage() {
+  const mobileAccess = useMobileDeviceAccess();
+
+  if (mobileAccess === "checking") {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center overflow-hidden">
+        <p>접속 환경을 확인하는 중...</p>
+      </div>
+    );
+  }
+
+  if (mobileAccess === "blocked") {
+    return <MobileBlockedTownPage />;
+  }
+
+  return <TownSingleTabGate />;
+}
+
+function TownSingleTabGate() {
   const entryStatus = useSingleTownTabEntry();
 
   if (entryStatus === "checking") {
@@ -125,5 +144,15 @@ function BlockedTownPage() {
         </aside>
       </div>
     </div>
+  );
+}
+
+function MobileBlockedTownPage() {
+  return (
+    <main className="flex h-screen items-center justify-center overflow-hidden bg-gray-100 p-4">
+      <div className="flex w-full max-w-sm items-center justify-center bg-white p-6">
+        <MobileAccessBlockedNotice />
+      </div>
+    </main>
   );
 }

--- a/src/features/deviceAccess/hooks/useMobileDeviceAccess.ts
+++ b/src/features/deviceAccess/hooks/useMobileDeviceAccess.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from "react";
+
+import { isMobileUserAgent } from "../model/mobileDevice";
+
+export type MobileDeviceAccessStatus = "checking" | "allowed" | "blocked";
+
+function subscribeToDeviceAccessSnapshot() {
+  return () => {};
+}
+
+function getServerDeviceAccessSnapshot(): MobileDeviceAccessStatus {
+  return "checking";
+}
+
+function getClientDeviceAccessSnapshot(): MobileDeviceAccessStatus {
+  if (typeof navigator === "undefined") {
+    return "allowed";
+  }
+
+  return isMobileUserAgent(navigator.userAgent) ? "blocked" : "allowed";
+}
+
+export function useMobileDeviceAccess(): MobileDeviceAccessStatus {
+  return useSyncExternalStore(
+    subscribeToDeviceAccessSnapshot,
+    getClientDeviceAccessSnapshot,
+    getServerDeviceAccessSnapshot,
+  );
+}

--- a/src/features/deviceAccess/index.ts
+++ b/src/features/deviceAccess/index.ts
@@ -3,3 +3,4 @@ export {
   type MobileDeviceAccessStatus,
 } from "./hooks/useMobileDeviceAccess";
 export { isMobileUserAgent } from "./model/mobileDevice";
+export { MobileAccessBlockedNotice } from "./ui/MobileAccessBlockedNotice";

--- a/src/features/deviceAccess/index.ts
+++ b/src/features/deviceAccess/index.ts
@@ -1,0 +1,5 @@
+export {
+  useMobileDeviceAccess,
+  type MobileDeviceAccessStatus,
+} from "./hooks/useMobileDeviceAccess";
+export { isMobileUserAgent } from "./model/mobileDevice";

--- a/src/features/deviceAccess/model/mobileDevice.ts
+++ b/src/features/deviceAccess/model/mobileDevice.ts
@@ -1,0 +1,16 @@
+export function isMobileUserAgent(userAgent: string): boolean {
+  const normalizedUserAgent = userAgent.toLowerCase();
+
+  if (!normalizedUserAgent) {
+    return false;
+  }
+
+  /**
+   * Chrome의 User-Agent 축소 정책으로 인해 향후 userAgentData 보완이 필요할 수 있다.
+   */
+  return (
+    normalizedUserAgent.includes("iphone") ||
+    normalizedUserAgent.includes("ipod") ||
+    (normalizedUserAgent.includes("android") && normalizedUserAgent.includes("mobile"))
+  );
+}

--- a/src/features/deviceAccess/ui/MobileAccessBlockedNotice.tsx
+++ b/src/features/deviceAccess/ui/MobileAccessBlockedNotice.tsx
@@ -1,0 +1,50 @@
+import { CHARACTER_CONFIGS } from "@/shared/constants";
+
+import Image from "next/image";
+
+interface MobileAccessBlockedNoticeProps {
+  className?: string;
+  showCharacterVisual?: boolean;
+}
+
+const blockedNoticeCharacter = CHARACTER_CONFIGS["p-girl"];
+
+export function MobileAccessBlockedNotice({
+  className,
+  showCharacterVisual = true,
+}: MobileAccessBlockedNoticeProps) {
+  return (
+    <section aria-labelledby="mobile-access-blocked-title" className={className}>
+      <div className="space-y-4 text-center">
+        <h2 id="mobile-access-blocked-title" className="text-xl font-semibold text-gray-900">
+          모바일 환경은 아직 지원하지 않습니다
+        </h2>
+        <p className="text-sm leading-6 text-gray-600">
+          현재 도파민또는 PC 브라우저에서 안정적으로 이용할 수 있습니다.
+        </p>
+        {showCharacterVisual ? (
+          <div className="pt-6">
+            <MobileAccessBlockedCharacterVisual />
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function MobileAccessBlockedCharacterVisual() {
+  return (
+    <div aria-hidden="true" className="flex justify-center">
+      <div className="relative flex h-28 w-32 items-end justify-center px-4 py-2">
+        <Image
+          src={blockedNoticeCharacter.previewAssetUrl}
+          alt=""
+          width={blockedNoticeCharacter.previewImageWidth}
+          height={blockedNoticeCharacter.previewImageHeight}
+          className="h-24 w-auto object-contain opacity-35 grayscale [image-rendering:pixelated]"
+          unoptimized
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/home/ui/HomeSingleTownTabGate.tsx
+++ b/src/widgets/home/ui/HomeSingleTownTabGate.tsx
@@ -1,9 +1,29 @@
 "use client";
 
 import { NicknameForm } from "@/features/auth/ui/NicknameForm";
+import { MobileAccessBlockedNotice, useMobileDeviceAccess } from "@/features/deviceAccess";
 import { SingleTownTabBlockedNotice, useSingleTownTabBlockStatus } from "@/features/singleTownTab";
 
 export function HomeSingleTownTabGate() {
+  const mobileAccess = useMobileDeviceAccess();
+
+  if (mobileAccess === "checking") {
+    return <p className="text-center text-sm text-gray-500">접속 환경을 확인하는 중...</p>;
+  }
+
+  if (mobileAccess === "blocked") {
+    return (
+      <>
+        <h1 className="font-display mb-4 text-center text-2xl">도파민또</h1>
+        <MobileAccessBlockedNotice />
+      </>
+    );
+  }
+
+  return <HomeSingleTownTabGateContent />;
+}
+
+function HomeSingleTownTabGateContent() {
   const entryStatus = useSingleTownTabBlockStatus();
 
   if (entryStatus === "checking") {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

이슈 #140 대응으로 모바일 브라우저 접속 제한 기능을 추가했습니다.

- User-Agent 기반 모바일 접속 판정 로직을 추가했습니다.
- 클라이언트에서 모바일 접근 상태를 확인하는 `useMobileDeviceAccess` 훅을 추가했습니다.
- 모바일 환경에서는 홈(`/`)과 타운(`/town`)에서 PC 브라우저 이용 안내 UI를 표시하도록 했습니다.
- `/town`에서는 모바일 차단 시 `TownEngine`, 채팅, 접속자 패널, 음성 UI, 툴바가 렌더링되지 않도록
처리했습니다.


## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)
<img width="591" height="1280" alt="photo_2026-07-18_23-32-00" src="https://github.com/user-attachments/assets/123903e7-63af-47e2-9f0f-5acbbabbc2db" />



## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

 - **주의깊게 봐주길 원하는 부분:**
    - 모바일 판정은 화면 너비가 아니라 User-Agent 기준으로 처리했습니다.
    - PC에서 브라우저 창만 좁힌 경우에는 차단하지 않습니다.
    - `useSingleTownTabEntry`는 현재 탭을 타운 입장 탭으로 등록하는 역할을 합니다. 모바일 사용자가 `/town`에
  직접 접근했을 때 이 훅이 먼저 실행되면, 차단 안내만 보여주더라도 탭 입장 상태가 기록될 수 있어 
모바일 접속 여부를 먼저 확인하도록 분리했습니다.

  - **함께 고민하고 싶은 부분:**
    - iPadOS 13+ 환경은 기본적으로 데스크톱 User-Agent를 전송하므로 현재는 PC로 취급합니다. 
    추후 iPad까지 제한해야 한다면 `navigator.maxTouchPoints` 등을 함께 보는 별도 정책이 필요할 수 있습니다.
    - Chrome 계열 브라우저의 User-Agent 축소 정책이 확대되면 `navigator.userAgentData` 기반 보완도 검
    토가 필요할 수 있습니다.

  - **기타 참고사항:**
    - 검증:
     - Desktop `/`, `/town` 기존 흐름 확인
     - iPhone: Safari, Chrome, 카카오/네이버 인앱 브라우저
     - Android: Chrome, 카카오/네이버 인앱 브라우저
   