### PR TITLE
[feature] 반응형 레이아웃 개선  #139

### DIFF
--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -113,11 +113,11 @@ function ActiveTownPage() {
 
   return (
     <div className="flex h-dvh flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-w-0 flex-1 items-center justify-center p-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:min-w-3xl lg:flex-row">
+        <div className="flex min-h-0 min-w-0 flex-1 items-center justify-center p-4">
           <TownEngine />
         </div>
-        <div className="flex h-full w-96 min-w-64 shrink-0 flex-col overflow-hidden border-l">
+        <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden border-t lg:h-full lg:w-96 lg:min-w-96 lg:flex-none lg:border-l lg:border-t-0">
           {panelContent}
         </div>
       </div>
@@ -133,13 +133,13 @@ function ActiveTownPage() {
 function BlockedTownPage() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-w-0 flex-1 items-center justify-center p-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:min-w-3xl lg:flex-row">
+        <div className="flex min-h-0 min-w-0 flex-1 items-center justify-center p-4">
           <div className="flex h-full w-full items-center justify-center rounded-lg border-4 border-gray-800 bg-black p-6 shadow-2xl">
             <SingleTownTabBlockedNotice className="rounded-lg bg-white p-6" />
           </div>
         </div>
-        <aside className="flex h-full w-96 min-w-64 shrink-0 items-center justify-center border-l bg-gray-50 p-6">
+        <aside className="flex min-h-0 w-full flex-1 items-center justify-center border-t bg-gray-50 p-6 lg:h-full lg:w-96 lg:min-w-96 lg:flex-none lg:border-l lg:border-t-0">
           <p className="text-center text-sm leading-6 text-gray-500">
             채팅은 기존 탭에서 이용 중입니다.
           </p>

--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -30,7 +30,7 @@ export default function TownPage() {
 
   if (mobileAccess === "checking") {
     return (
-      <div className="flex h-screen flex-col items-center justify-center overflow-hidden">
+      <div className="flex h-dvh flex-col items-center justify-center overflow-hidden">
         <p>접속 환경을 확인하는 중...</p>
       </div>
     );
@@ -48,7 +48,7 @@ function TownSingleTabGate() {
 
   if (entryStatus === "checking") {
     return (
-      <div className="flex h-screen flex-col items-center justify-center overflow-hidden">
+      <div className="flex h-dvh flex-col items-center justify-center overflow-hidden">
         <p>타운 입장 상태를 확인하는 중...</p>
       </div>
     );
@@ -94,7 +94,7 @@ function ActiveTownPage() {
 
   if (isLoading && !userNickname) {
     return (
-      <div className="flex h-screen flex-col items-center justify-center overflow-hidden">
+      <div className="flex h-dvh flex-col items-center justify-center overflow-hidden">
         <p>사용자 정보를 불러오는 중...</p>
       </div>
     );
@@ -112,12 +112,14 @@ function ActiveTownPage() {
     );
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1">
-        <div className="flex flex-1 items-center justify-center p-4">
+    <div className="flex h-dvh flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 items-center justify-center p-4">
           <TownEngine />
         </div>
-        <div className="flex h-full w-96 flex-col">{panelContent}</div>
+        <div className="flex h-full w-96 min-w-64 shrink-0 flex-col overflow-hidden border-l">
+          {panelContent}
+        </div>
       </div>
 
       {user?.id && userNickname ? (
@@ -130,14 +132,14 @@ function ActiveTownPage() {
 
 function BlockedTownPage() {
   return (
-    <div className="flex h-screen flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1">
-        <div className="flex flex-1 items-center justify-center p-4">
+    <div className="flex h-dvh flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 items-center justify-center p-4">
           <div className="flex h-full w-full items-center justify-center rounded-lg border-4 border-gray-800 bg-black p-6 shadow-2xl">
             <SingleTownTabBlockedNotice className="rounded-lg bg-white p-6" />
           </div>
         </div>
-        <aside className="flex h-full w-96 items-center justify-center border-l bg-gray-50 p-6">
+        <aside className="flex h-full w-96 min-w-64 shrink-0 items-center justify-center border-l bg-gray-50 p-6">
           <p className="text-center text-sm leading-6 text-gray-500">
             채팅은 기존 탭에서 이용 중입니다.
           </p>

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -134,8 +134,24 @@ export class TownScene extends Phaser.Scene {
       }
 
       const bounds = mapLoader.getMapBounds();
-      this.cameras.main.setBounds(bounds.x, bounds.y, bounds.width, bounds.height);
+      const cb = this.computeCameraBounds(
+        bounds,
+        this.cameras.main.width,
+        this.cameras.main.height,
+      );
+      this.cameras.main.setBounds(cb.x, cb.y, cb.width, cb.height);
       this.cameras.main.setZoom(GAME_CONFIG.CAMERA_ZOOM);
+
+      /** 화면 크기 변경 시 카메라 bounds를 재계산한다 */
+      const handleResize = () => {
+        const updated = this.computeCameraBounds(
+          bounds,
+          this.cameras.main.width,
+          this.cameras.main.height,
+        );
+        this.cameras.main.setBounds(updated.x, updated.y, updated.width, updated.height);
+      };
+      this.scale.on(Phaser.Scale.Events.RESIZE, handleResize);
     }
 
     // 방향별 걷기 애니메이션 등록 (가로 3열, 세로 4행 기준)
@@ -307,6 +323,7 @@ export class TownScene extends Phaser.Scene {
     // Scene 종료 시 구독 해제 설정
     this.events.once("shutdown", () => {
       if (this.unsubscribeStore) this.unsubscribeStore();
+      this.scale.off(Phaser.Scale.Events.RESIZE);
       this.remotePlayerSprites.clear();
       this.remotePlayerNames.clear();
       this.remotePlayerTargets.clear();
@@ -716,6 +733,25 @@ export class TownScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setDepth(depth)
       .setVisible(imageLayer.visible);
+  }
+
+  /**
+   * 맵이 캔버스보다 작을 때 중앙 정렬되도록 카메라 bounds를 계산한다.
+   * 맵이 캔버스보다 크거나 같으면 맵 bounds를 그대로 반환한다.
+   */
+  private computeCameraBounds(
+    mapBounds: { x: number; y: number; width: number; height: number },
+    camWidth: number,
+    camHeight: number,
+  ) {
+    const offsetX = Math.max(0, Math.floor((camWidth - mapBounds.width) / 2));
+    const offsetY = Math.max(0, Math.floor((camHeight - mapBounds.height) / 2));
+    return {
+      x: mapBounds.x - offsetX,
+      y: mapBounds.y - offsetY,
+      width: Math.max(mapBounds.width, camWidth),
+      height: Math.max(mapBounds.height, camHeight),
+    };
   }
 
   /**

--- a/src/widgets/chatPanel/ui/ChatPanel.tsx
+++ b/src/widgets/chatPanel/ui/ChatPanel.tsx
@@ -25,7 +25,7 @@ export function ChatPanel() {
   const villageName = VILLAGES[villageId as keyof typeof VILLAGES]?.name ?? villageId;
 
   return (
-    <>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <ChatPanelHeader villageName={villageName} isConnected={isConnected} />
       <ChatHistory
         key={roomId}
@@ -39,7 +39,7 @@ export function ChatPanel() {
         currentUserId={userId}
       />
       <MessageField onMessageSend={handleMessageSend} isConnected={isConnected} roomId={roomId} />
-    </>
+    </div>
   );
 }
 

--- a/src/widgets/townToolbar/ui/TownToolbar.tsx
+++ b/src/widgets/townToolbar/ui/TownToolbar.tsx
@@ -13,7 +13,7 @@ export function TownToolbar({ isSpeaker }: TownToolbarProps) {
   const isUsersPanel = activePanel === "users";
 
   return (
-    <div className="flex h-12 w-full items-center justify-end  border-t bg-white px-4">
+    <div className="flex h-12 w-full items-center justify-end border-t bg-white px-4">
       <PresenceToolbarButton
         isSpeaker={isSpeaker}
         isUsersPanel={isUsersPanel}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

Closes #139

좁은 브라우저 폭 또는 Chrome 분할 화면 환경에서 `/town` 레이아웃이 깨지지 않도록 반응형 구조를 개선했습니
다.

- `/town` 높이 기준을 `h-screen`에서 `h-dvh`로 변경
- `lg` 미만에서는 맵과 패널이 상하 배치되도록 수정
- `lg` 이상에서는 기존처럼 맵 좌측, 채팅/사용자 패널 우측 배치 유지
- 우측 패널은 넓은 화면에서 `w-96`, `min-w-96` 기준을 유지
- 맵+패널을 감싸는 영역에 최소 폭을 적용해, 특정 폭 이하에서 레이아웃이 과하게 줄어들지 않도록 조정
- `ChatPanel`에 flex 래퍼를 추가해 채팅 목록과 입력창의 overflow 흐름을 안정화
- 화면 크기 변경 시 Phaser 카메라 bounds를 다시 계산하도록 보완

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

 - 넓은 화면: 기존 좌우 레이아웃 유지 + 브라우저 폭이 1900px 이상일 때 가운데 정렬 
<img width="2147" height="1198" alt="스크린샷 2026-07-19 오전 4 08 04" src="https://github.com/user-attachments/assets/13154c23-a1eb-46ea-b566-109309dfa103" />

- 좁은 화면 / 분할 화면: 채팅 패널이 맵 아래로 내려가 `w-full`로 표시
<img width="1549" height="1196" alt="스크린샷 2026-07-19 오전 4 07 32" src="https://github.com/user-attachments/assets/43e310e2-32b7-417e-912a-01b176472428" />

## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
    - `lg` breakpoint 기준으로 상하/좌우 레이아웃이 전환되는 흐름이 괜찮은지 확인 부탁드립니다.
    - 맵+패널을 감싸는 영역에 최소 폭을 적용해, 일정 폭 이하에서는 레이아웃이 더 줄어들지 않도록 했습니다.
    - Phaser 카메라 bounds를 resize 시점에 다시 계산하도록 추가했는데, 실제 분할 화면 전환 시 맵 위치가 자
    연스러운지도 확인 부탁드립니다.

  - **함께 고민하고 싶은 부분:**
    - 최소 폭 이하에서 가로 스크롤을 별도로 제공하지 않고 기존 overflow 흐름을 유지했는데, 사용성 측면에서
    더 나은 방향이 있을지 의견 부탁드립니다.