### PR TITLE
[feature] Google Analytics(GA4) 연동

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -21,5 +21,10 @@ NODE_ENV=development
 # Enable/disable Garbage Collection for chat messages
 NEXT_PUBLIC_CHAT_GC_ENABLED=true
 
+# Google Analytics 4 Configuration
+# GA4 Measurement ID (Admin > Data Streams > Web에서 확인)
+# 값이 비어 있으면 Analytics 스크립트는 로드되지 않습니다.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
 # Optional: Database URL (if needed for server-side operations)
 # DATABASE_URL=postgresql://username:password@localhost:5432/database_name

--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ NEXT_PUBLIC_SPEAKER_NICKNAME=your-speaker-nickname
 
 # Development Configuration
 NODE_ENV=development
+
+# Google Analytics 4 Configuration (선택)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
+
+> `NEXT_PUBLIC_GA_MEASUREMENT_ID`를 비워두면 Analytics 스크립트 자체가 로드되지 않습니다. 개발 환경에서 실제 GA 이벤트가 섞이는 것을 원하지 않는다면 값을 비워두거나, 개발/운영용 GA4 속성을 각각 만들어 Measurement ID를 환경별로 다르게 설정하세요.
 
 ### 개발 서버 실행
 
@@ -222,11 +227,21 @@ npm run build
 
 #### 필요한 프로바이더들
 
-| 프로바이더         | 용도                        | 라이브러리            | 특징                 |
-| ------------------ | --------------------------- | --------------------- | -------------------- |
-| `QueryProvider`    | 서버 상태 관리 및 캐싱      | @tanstack/react-query | 전역 쿼리 클라이언트 |
-| `SupabaseProvider` | 데이터베이스 및 실시간 기능 | @supabase/ssr         | 익명 접속, SSR 지원  |
-| `AppProviders`     | 모든 프로바이더 통합        | -                     | 계층적 구조          |
+| 프로바이더          | 용도                         | 라이브러리            | 특징                              |
+| ------------------- | ---------------------------- | --------------------- | --------------------------------- |
+| `QueryProvider`     | 서버 상태 관리 및 캐싱       | @tanstack/react-query | 전역 쿼리 클라이언트              |
+| `SupabaseProvider`  | 데이터베이스 및 실시간 기능  | @supabase/ssr         | 익명 접속, SSR 지원               |
+| `AnalyticsProvider` | GA4 초기화 및 Page View 추적 | -                     | Measurement ID 미설정 시 비활성화 |
+| `AppProviders`      | 모든 프로바이더 통합         | -                     | 계층적 구조                       |
+
+---
+
+## 📊 Google Analytics(GA4) 연동
+
+- **위치**: `src/app/providers/AnalyticsProvider.tsx`에서 `gtag.js` 스크립트 로드와 초기화를 담당하고, `AppProviders`를 통해 루트 레이아웃에 연결됩니다. 라이브러리 추가 없이 Next.js 내장 `next/script`만 사용합니다.
+- **환경변수**: `NEXT_PUBLIC_GA_MEASUREMENT_ID`(`.env.local`)가 없으면 `AnalyticsProvider`가 스크립트를 전혀 렌더링하지 않아, 로컬 개발 중 GA 이벤트가 실수로 전송되는 것을 방지합니다. 개발/운영 환경 모두 이 값만 채워주면 동일한 코드로 동작하며, 필요 시 환경별로 다른 Measurement ID를 지정할 수 있습니다.
+- **Page View 추적**: `src/shared/hooks/useAnalyticsPageView.ts`가 `usePathname`/`useSearchParams`로 라우트 변경을 감지해 `page_view`를 전송합니다. App Router는 클라이언트 사이드 네비게이션 시 새 문서 로드가 없기 때문에, `gtag('config', ..., { send_page_view: false })`로 자동 전송을 끄고 라우트 변경마다 직접 전송하는 방식을 사용합니다(`/` ↔ `/town` 이동 포함). 이 훅은 `useSearchParams`를 사용하므로 `Suspense` 경계 안에서만 렌더링됩니다.
+- **초기화와 이벤트 추적 분리**: 스크립트 로드/초기화(`AnalyticsProvider`)와 실제 이벤트 전송 함수(`src/shared/lib/analytics/gtag.ts`의 `pageview`, `trackEvent`)를 분리해, 이후 기능 코드에서는 `trackEvent({ action, category, label, value })`만 임포트해 커스텀 이벤트를 보내면 됩니다.
 
 ---
 
@@ -264,9 +279,9 @@ npm run build
 
 ## 🔌 환경 및 프로바이더 체크리스트
 
-- `.env.local.example`을 복사하여 `.env.local`을 만들고 Supabase, Cloudflare RealtimeKit, speaker 닉네임, NODE_ENV 값을 실제 키로 설정합니다.
-- React Query(`@tanstack/react-query`), Supabase(`@supabase/supabase-js`, `@supabase/ssr`), Zustand, Phaser 등 주요 라이브러리가 `src/app/providers/` 내부에서 초기화됩니다.
-- 필요한 프로바이더는 `QueryProvider`, `SupabaseProvider`, `AppProviders`이며, Supabase는 익명 접속·SSR·Realtime을 지원하고 AppProviders가 전체 계층을 감쌉니다.
+- `.env.local.example`을 복사하여 `.env.local`을 만들고 Supabase, Cloudflare RealtimeKit, speaker 닉네임, NODE_ENV, GA4 Measurement ID 값을 실제 키로 설정합니다.
+- React Query(`@tanstack/react-query`), Supabase(`@supabase/supabase-js`, `@supabase/ssr`), Zustand, Phaser, GA4(`next/script`) 등 주요 라이브러리/스크립트가 `src/app/providers/` 내부에서 초기화됩니다.
+- 필요한 프로바이더는 `QueryProvider`, `SupabaseProvider`, `AnalyticsProvider`, `AppProviders`이며, Supabase는 익명 접속·SSR·Realtime을, AnalyticsProvider는 GA4 스크립트 로드와 Page View 추적을 담당하고 AppProviders가 전체 계층을 감쌉니다.
 - 상태 관리는 React Query가 서버 데이터를, Zustand가 클라이언트 상태를 담당하며, 관련 스토어는 FSD 레이어별 `model/store`에 배치합니다.
 - Cloudflare RealtimeKit, Phaser 게임 엔진 설정, Supabase Realtime 설정 등은 위 구성이 정상적으로 작동할 수 있도록 환경변수, provider hooks, `AppProviders` 계층에서 연결합니다.
 

--- a/src/app/providers/AnalyticsProvider.tsx
+++ b/src/app/providers/AnalyticsProvider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { GA_MEASUREMENT_ID, isAnalyticsEnabled } from "@/shared/config/analytics";
+import { useAnalyticsPageView } from "@/shared/hooks/useAnalyticsPageView";
+
+import { Suspense } from "react";
+
+import Script from "next/script";
+
+interface AnalyticsProviderProps {
+  children: React.ReactNode;
+}
+
+/** GA4 초기화 스크립트를 로드하고, 라우트 변경마다 Page View를 전송합니다. */
+const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => {
+  if (!isAnalyticsEnabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){window.dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', { send_page_view: false });
+        `}
+      </Script>
+      <Suspense fallback={null}>
+        <AnalyticsPageViewTracker />
+      </Suspense>
+      {children}
+    </>
+  );
+};
+
+/** useSearchParams를 사용하므로 Suspense 경계 안에서만 렌더링됩니다. */
+const AnalyticsPageViewTracker = () => {
+  useAnalyticsPageView();
+  return null;
+};
+
+export default AnalyticsProvider;

--- a/src/app/providers/AppProviders.tsx
+++ b/src/app/providers/AppProviders.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import AnalyticsProvider from "./AnalyticsProvider";
 import QueryProvider from "./QueryProvider";
 import SupabaseProvider from "./SupabaseProvider";
 
@@ -10,7 +11,9 @@ interface AppProvidersProps {
 const AppProviders = ({ children }: AppProvidersProps) => {
   return (
     <QueryProvider>
-      <SupabaseProvider>{children}</SupabaseProvider>
+      <SupabaseProvider>
+        <AnalyticsProvider>{children}</AnalyticsProvider>
+      </SupabaseProvider>
     </QueryProvider>
   );
 };

--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -4,4 +4,5 @@
 // UI 컴포넌트 레이어
 export { default as QueryProvider } from "./QueryProvider";
 export { default as SupabaseProvider } from "./SupabaseProvider";
+export { default as AnalyticsProvider } from "./AnalyticsProvider";
 export { default as AppProviders } from "./AppProviders";

--- a/src/shared/config/analytics.ts
+++ b/src/shared/config/analytics.ts
@@ -1,0 +1,4 @@
+// GA4 Measurement ID. 값이 없으면 Analytics 관련 기능은 전부 비활성화됩니다.
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+export const isAnalyticsEnabled = Boolean(GA_MEASUREMENT_ID);

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -1,3 +1,4 @@
 // Config - 설정 관련
 // 프로젝트 설정 파일들을 export
 export * from "./supabase.client";
+export * from "./analytics";

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -5,3 +5,4 @@ export * from "./useIntersectionObserver";
 export * from "./useVisiblePageTracking";
 export * from "./useAutoResizeTextarea";
 export * from "./useDebouncedValue";
+export * from "./useAnalyticsPageView";

--- a/src/shared/hooks/useAnalyticsPageView.ts
+++ b/src/shared/hooks/useAnalyticsPageView.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { pageview } from "@/shared/lib/analytics";
+
+import { useEffect } from "react";
+
+import { usePathname, useSearchParams } from "next/navigation";
+
+/**
+ * 라우트(pathname, query) 변경을 감지해 GA4에 Page View 이벤트를 전송합니다.
+ * useSearchParams를 사용하므로 반드시 Suspense 경계 내부에서 사용해야 합니다.
+ */
+export function useAnalyticsPageView() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const query = searchParams.toString();
+    pageview(query ? `${pathname}?${query}` : pathname);
+  }, [pathname, searchParams]);
+}

--- a/src/shared/lib/analytics/gtag.ts
+++ b/src/shared/lib/analytics/gtag.ts
@@ -1,0 +1,37 @@
+import { GA_MEASUREMENT_ID, isAnalyticsEnabled } from "@/shared/config/analytics";
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+interface AnalyticsEventParams {
+  action: string;
+  category?: string;
+  label?: string;
+  value?: number;
+}
+
+/** 라우트 변경 시 GA4에 Page View 이벤트를 전송합니다. */
+export const pageview = (url: string) => {
+  if (!isAnalyticsEnabled || typeof window === "undefined" || typeof window.gtag !== "function") {
+    return;
+  }
+
+  window.gtag("config", GA_MEASUREMENT_ID, { page_path: url });
+};
+
+/** GA4에 커스텀 이벤트를 전송합니다. */
+export const trackEvent = ({ action, category, label, value }: AnalyticsEventParams) => {
+  if (!isAnalyticsEnabled || typeof window === "undefined" || typeof window.gtag !== "function") {
+    return;
+  }
+
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value,
+  });
+};

--- a/src/shared/lib/analytics/index.ts
+++ b/src/shared/lib/analytics/index.ts
@@ -1,0 +1,1 @@
+export { pageview, trackEvent } from "./gtag";

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -8,3 +8,4 @@ export {
 export { toDate, isSameDay, formatTime, formatDate, formatJoinedTime } from "./datetime";
 export { getChatChannelName } from "./realtime/getChatChannelName";
 export { getChatRoomId } from "./realtime/getChatRoomId";
+export { pageview, trackEvent } from "./analytics";


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_GA_MEASUREMENT_ID` 환경변수 기반으로 GA4를 연동합니다 (값이 없으면 스크립트 자체를 로드하지 않음).
- `src/app/providers/AnalyticsProvider.tsx`에서 `next/script`로 gtag.js를 로드/초기화하고, `AppProviders`를 통해 루트 레이아웃에 연결합니다.
- App Router는 클라이언트 사이드 네비게이션 시 새 문서 로드가 없어 자동 page_view가 잡히지 않으므로, `send_page_view: false`로 자동 전송을 끄고 `useAnalyticsPageView` 훅(`usePathname`/`useSearchParams`)이 라우트 변경(`/` ↔ `/town`)마다 직접 `page_view`를 전송합니다.
- 초기화 코드(`AnalyticsProvider`)와 이벤트 전송 유틸(`src/shared/lib/analytics/gtag.ts`의 `pageview`, `trackEvent`)을 분리해, 이후 기능 코드에서는 `trackEvent(...)`만 임포트해 커스텀 이벤트를 보낼 수 있습니다.
- 추가 라이브러리 없이 Next.js 내장 `next/script`만 사용했습니다.
- `.env.local.example`과 README에 환경변수 설정 방법을 문서화했습니다.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .` (기존 경고 외 신규 에러/경고 없음)
- [x] `npm test`
- [x] `npm run build` — GA 비활성/활성 두 경우 모두 `/`, `/town`이 정적(○)으로 유지되는지 확인 (Suspense 경계로 `useSearchParams`가 격리됨)
- [x] Playwright로 실제 브라우저 검증: 초기 로드 시 `page_path: "/"` 전송 + `google-analytics.com/g/collect`로 실제 page_view 히트 발생 확인, SPA 라우트 변경 시 `page_path: "/town"`으로 추가 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)