### PR TITLE
[fix] Realtime 채널 재연결 안정성 개선

### DIFF
--- a/src/entities/village/lib/visibility.ts
+++ b/src/entities/village/lib/visibility.ts
@@ -1,12 +1,8 @@
 import { VILLAGE_IDS } from "../config/villageData";
 import { VillageId } from "../model/types";
 
-/** 현재 village에서 직접 이어진 village 목록을 반환한다. */
-export const getAdjacentVillages = (villageId: VillageId): VillageId[] =>
-  VILLAGE_IDS.filter((adjacentVillageId) => adjacentVillageId !== villageId);
-
-/** 현재 village 자신과 인접 village를 합친 visible 범위를 반환한다. */
+/** 모든 village의 유저가 서로의 이동/presence를 볼 수 있도록 전체 village를 반환한다. */
 export const getVisibleVillages = (villageId: VillageId): VillageId[] => [
   villageId,
-  ...VILLAGE_IDS.filter((visibleVillageId) => visibleVillageId !== villageId),
+  ...VILLAGE_IDS.filter((otherVillageId) => otherVillageId !== villageId),
 ];

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -46,7 +46,9 @@ interface MovementStore extends MovementState {
 export const useMovementStore = create<MovementStore>()(
   subscribeWithSelector((set, get) => {
     let lastFlushTime = 0;
-    const FLUSH_INTERVAL = 100;
+    // 전체 village 가시성(다른 마을 사람도 보임) 기준으로, 동시 접속 50명 규모에서도
+    // player_move 트래픽이 realtime 소켓을 불안정하게 만들지 않도록 100ms(초당 10회)에서 낮췄다.
+    const FLUSH_INTERVAL = 250;
     let isSyncing = false;
     let flushTimeout: ReturnType<typeof setTimeout> | null = null;
     /**

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -47,7 +47,7 @@ export const useMovementStore = create<MovementStore>()(
   subscribeWithSelector((set, get) => {
     let lastFlushTime = 0;
     // 전체 village 가시성(다른 마을 사람도 보임) 기준으로, 동시 접속 50명 규모에서도
-    // player_move 트래픽이 realtime 소켓을 불안정하게 만들지 않도록 100ms(초당 10회)에서 낮췄다.
+    // player_move 트래픽이 realtime 소켓을 불안정하게 만들지 않도록 100ms(초당 10회) → 250ms(초당 4회)로 늘렸다.
     const FLUSH_INTERVAL = 250;
     let isSyncing = false;
     let flushTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/src/features/presence/model/useTownPresence.ts
+++ b/src/features/presence/model/useTownPresence.ts
@@ -125,6 +125,10 @@ export const useTownPresence = () => {
         audioEnabled,
       };
 
+      // 이동(village 경계 통과) 중 track() 실패가 몰려서 강제 재연결로 이어지는지
+      // 진단하기 위해 소요 시간을 함께 기록한다.
+      const attemptStartedAt = Date.now();
+
       try {
         const res = await channel.track(payload);
         if (res !== "ok") {
@@ -132,13 +136,19 @@ export const useTownPresence = () => {
         }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        console.warn(`[useTownPresence] Track failed (Attempt ${retryCount + 1}): ${errorMessage}`);
+        console.warn(
+          `[useTownPresence] track 실패 (userId=${userId}, 시도=${retryCount + 1}회, ` +
+            `소요시간=${Date.now() - attemptStartedAt}ms, 채널상태=${channelStatus}): ${errorMessage}`,
+        );
 
         // cleanup 이후라면 reconnect와 재시도 타이머를 등록하지 않는다.
         if (isCancelled) return;
 
         if (retryCount >= 3) {
-          console.warn(`[useTownPresence] Start reconnecting due to track failure.`);
+          console.warn(
+            `[useTownPresence] track 반복 실패로 town:main을 재연결합니다 ` +
+              `(userId=${userId}, villageId=${debouncedVillageId}, 채널상태=${channelStatus})`,
+          );
           reconnect();
           return;
         }

--- a/src/features/voiceChat/ui/TownVoiceClient.tsx
+++ b/src/features/voiceChat/ui/TownVoiceClient.tsx
@@ -110,6 +110,19 @@ export function TownVoiceClient({
     let activeMeetingCleanup: (() => void) | undefined;
 
     /**
+     * 새로고침/탭 종료/앱 강제 종료 시 React effect cleanup(leaveRoom)이 실행되지 않을 수 있어,
+     * pagehide에서 best-effort로 한 번 더 시도한다. 같은 userId로 즉시 재입장하면
+     * 서버에 이전 세션이 잠시 남아있어 새 세션의 트랙 구독이 꼬일 수 있기 때문이다.
+     */
+    const handlePageHide = () => {
+      const activeMeeting = meetingRef.current;
+      if (joinedRoom && activeMeeting?.self.roomJoined) {
+        void activeMeeting.leaveRoom("left");
+      }
+    };
+    window.addEventListener("pagehide", handlePageHide);
+
+    /**
      * 토큰 발급, RealtimeKit 초기화, room join, speaker 마이크 활성화까지
      * 하나의 순서로 처리한다.
      */
@@ -275,6 +288,7 @@ export function TownVoiceClient({
     void connect();
 
     return () => {
+      window.removeEventListener("pagehide", handlePageHide);
       isMounted = false;
       isAudioTogglingRef.current = false;
       const activeMeeting = meetingRef.current;

--- a/src/features/voiceChat/ui/TownVoiceClient.tsx
+++ b/src/features/voiceChat/ui/TownVoiceClient.tsx
@@ -123,6 +123,22 @@ export function TownVoiceClient({
     window.addEventListener("pagehide", handlePageHide);
 
     /**
+     * bfcache 복원(pageshow, persisted) 시 서버 세션은 이미 pagehide에서 끊겼지만
+     * 로컬 상태는 그대로 남아있으므로 connect()를 다시 실행해 재연결한다.
+     */
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (!event.persisted || !isMounted) return;
+
+      joinedRoom = false;
+      activeMeetingCleanup?.();
+      activeMeetingCleanup = undefined;
+      meetingRef.current = null;
+
+      void connect();
+    };
+    window.addEventListener("pageshow", handlePageShow);
+
+    /**
      * 토큰 발급, RealtimeKit 초기화, room join, speaker 마이크 활성화까지
      * 하나의 순서로 처리한다.
      */
@@ -289,6 +305,7 @@ export function TownVoiceClient({
 
     return () => {
       window.removeEventListener("pagehide", handlePageHide);
+      window.removeEventListener("pageshow", handlePageShow);
       isMounted = false;
       isAudioTogglingRef.current = false;
       const activeMeeting = meetingRef.current;

--- a/src/shared/lib/realtime/townChannelManager.ts
+++ b/src/shared/lib/realtime/townChannelManager.ts
@@ -14,7 +14,8 @@ const SOCKET_RESET_DEDUPE_MS = 3000;
 // 소켓이 손상된 경우 "SUBSCRIBED -> CLOSED -> (재연결 성공) -> SUBSCRIBED -> CLOSED -> ..."처럼
 // 매번 재연결에는 성공하지만 곧바로 다시 끊기는 flapping 패턴으로 나타난다. 이 경우
 // SUBSCRIBED에 도달할 때마다 reconnectCount가 0으로 리셋되어 MAX_AUTO_RECONNECT에 영영 도달하지 못한다.
-// 그래서 "짧은 시간 안에 반복 실패"를 별도로 감지해 소켓 리셋을 트리거한다.
+// 그래서 SUBSCRIBED 후 FLAP_STABILITY_MS를 못 버틴 실패가 (간격 무관) 누적
+// MAX_FLAPS_BEFORE_SOCKET_RESET회에 도달하면 소켓 리셋을 트리거한다.
 const FLAP_STABILITY_MS = 8000;
 const MAX_FLAPS_BEFORE_SOCKET_RESET = 3;
 // realtime-js: disconnect() 직후 소켓이 실제로 닫히기 전에 connect()를 부르면 no-op으로 무시된다.
@@ -41,6 +42,7 @@ interface TownChannelGlobalState {
   lastSocketResetAt: number;
   recentFailureCounts: Map<string, number>;
   stabilityTimers: Map<string, ReturnType<typeof setTimeout>>;
+  lastSubscribedAt: Map<string, number>;
   // visibilitychange 리스너가 탭 복귀 시 재연결을 걸 때 필요한, 채널별 마지막 userId.
   channelUserIds: Map<string, string>;
   visibilityListenerRegistered: boolean;
@@ -64,6 +66,7 @@ function getGlobals(): TownChannelGlobalState {
       lastSocketResetAt: 0,
       recentFailureCounts: new Map(),
       stabilityTimers: new Map(),
+      lastSubscribedAt: new Map(),
       channelUserIds: new Map(),
       visibilityListenerRegistered: false,
       lastSupabaseClient: null,
@@ -117,7 +120,7 @@ const scheduleFlapStabilityReset = (channelName: string) => {
   globals.stabilityTimers.set(channelName, timer);
 };
 
-/** 실패를 기록하고, 짧은 시간 안에 반복 실패 중인지(flapping) 여부를 반환한다. */
+/** 실패를 기록하고, SUBSCRIBED 후 안정 유지 시간을 채우지 못한 실패가 누적됐는지(flapping) 여부를 반환한다. */
 const recordChannelFailure = (channelName: string): boolean => {
   clearStabilityTimer(channelName);
   const count = (globals.recentFailureCounts.get(channelName) || 0) + 1;
@@ -130,6 +133,7 @@ const notifyStatusObservers = (channelName: string, status: ChannelStatus, err?:
 
   if (status === "SUBSCRIBED") {
     globals.reconnectCounts.set(channelName, 0);
+    globals.lastSubscribedAt.set(channelName, Date.now());
     scheduleFlapStabilityReset(channelName);
   }
 
@@ -325,11 +329,18 @@ const scheduleConnect = ({
       ) {
         const isFlapping = recordChannelFailure(channelName);
         if (isFlapping) {
+          const lastSubscribedAt = globals.lastSubscribedAt.get(channelName);
+          console.info("[townChannelManager] socket reset", {
+            channelName,
+            flapCount: globals.recentFailureCounts.get(channelName) || 0,
+            stableDurationMs: lastSubscribedAt ? Date.now() - lastSubscribedAt : null,
+          });
+
           void resetRealtimeSocket(
             supabase,
             userId,
             channelName,
-            `${FLAP_STABILITY_MS}ms 이내에 ${MAX_FLAPS_BEFORE_SOCKET_RESET}회 이상 반복 실패(flapping)함`,
+            `SUBSCRIBED 후 ${FLAP_STABILITY_MS}ms 안정 유지를 채우지 못한 실패가 ${MAX_FLAPS_BEFORE_SOCKET_RESET}회 누적됨(flapping)`,
           );
           return;
         }
@@ -424,6 +435,7 @@ export const releaseTownChannel = ({
     globals.reconnectCounts.delete(channelName);
     clearStabilityTimer(channelName);
     globals.recentFailureCounts.delete(channelName);
+    globals.lastSubscribedAt.delete(channelName);
     globals.channelUserIds.delete(channelName);
   }, CHANNEL_CLEANUP_DELAY_MS);
 

--- a/src/shared/lib/realtime/townChannelManager.ts
+++ b/src/shared/lib/realtime/townChannelManager.ts
@@ -17,6 +17,10 @@ const SOCKET_RESET_DEDUPE_MS = 3000;
 // 그래서 "짧은 시간 안에 반복 실패"를 별도로 감지해 소켓 리셋을 트리거한다.
 const FLAP_STABILITY_MS = 8000;
 const MAX_FLAPS_BEFORE_SOCKET_RESET = 3;
+// realtime-js: disconnect() 직후 소켓이 실제로 닫히기 전에 connect()를 부르면 no-op으로 무시된다.
+// 타임아웃 초과 시에는 (onclose 누락 대비) 그냥 connect()를 시도한다.
+const SOCKET_CLOSE_POLL_INTERVAL_MS = 20;
+const SOCKET_CLOSE_WAIT_TIMEOUT_MS = 1000;
 
 type ChannelStatus = string;
 type StatusObserver = (status: ChannelStatus, err?: Error) => void;
@@ -158,13 +162,42 @@ const destroyChannel = (supabase: SupabaseClient, channelName: string) => {
   notifyStatusObservers(channelName, "CLOSED");
 };
 
+/** destroyChannel과 달리 removeChannel()의 완료(unsubscribe 완료)를 기다린다. */
+const destroyChannelAndWait = async (
+  supabase: SupabaseClient,
+  channelName: string,
+): Promise<void> => {
+  const channel = globals.channels.get(channelName);
+  if (!channel) return;
+
+  globals.channels.delete(channelName);
+  notifyStatusObservers(channelName, "CLOSED");
+  await supabase.removeChannel(channel);
+};
+
+const waitUntilSocketClosed = (supabase: SupabaseClient): Promise<void> =>
+  new Promise((resolve) => {
+    const startedAt = Date.now();
+
+    const check = () => {
+      const stillDisconnecting = supabase.realtime.isDisconnecting();
+      if (!stillDisconnecting || Date.now() - startedAt >= SOCKET_CLOSE_WAIT_TIMEOUT_MS) {
+        resolve();
+        return;
+      }
+      setTimeout(check, SOCKET_CLOSE_POLL_INTERVAL_MS);
+    };
+
+    check();
+  });
+
 /**
  * 채널을 아무리 새로 만들어도 계속 실패한다면, 문제는 채널이 아니라 그 밑에 있는
  * 하나의 WebSocket(소켓) 자체일 가능성이 높다. 이 경우 채널 객체를 갈아끼우는 것만으로는
  * 절대 회복되지 않는다 (새로고침이 고치는 이유가 바로 완전히 새 소켓을 여는 것이기 때문).
  * 그래서 소켓 자체를 끊었다 다시 연결하고, 현재 구독 중이던 채널을 전부 처음부터 다시 붙인다.
  */
-const resetRealtimeSocket = (
+const resetRealtimeSocket = async (
   supabase: SupabaseClient,
   userId: string,
   triggerChannelName: string,
@@ -185,13 +218,17 @@ const resetRealtimeSocket = (
 
   channelNamesToResume.forEach((name) => {
     clearConnectTimeout(name);
-    destroyChannel(supabase, name);
     globals.reconnectCounts.set(name, 0);
     clearStabilityTimer(name);
     globals.recentFailureCounts.set(name, 0);
   });
 
+  // removeChannel()이 끝나기 전에 disconnect()를 부르면 언바인드되지 않은 채널의 leave 메시지가
+  // 유실될 수 있으므로, 채널 정리를 먼저 완료한 뒤 소켓을 끊는다.
+  await Promise.all(channelNamesToResume.map((name) => destroyChannelAndWait(supabase, name)));
+
   supabase.realtime.disconnect();
+  await waitUntilSocketClosed(supabase);
   supabase.realtime.connect();
 
   channelNamesToResume.forEach((name) => {
@@ -221,7 +258,7 @@ const scheduleConnect = ({
 
   const reconnectCount = globals.reconnectCounts.get(channelName) || 0;
   if (reconnectCount >= MAX_AUTO_RECONNECT) {
-    resetRealtimeSocket(
+    void resetRealtimeSocket(
       supabase,
       userId,
       channelName,
@@ -288,7 +325,7 @@ const scheduleConnect = ({
       ) {
         const isFlapping = recordChannelFailure(channelName);
         if (isFlapping) {
-          resetRealtimeSocket(
+          void resetRealtimeSocket(
             supabase,
             userId,
             channelName,

--- a/src/shared/lib/realtime/townChannelManager.ts
+++ b/src/shared/lib/realtime/townChannelManager.ts
@@ -461,8 +461,6 @@ const reconnectStaleChannelsOnVisible = (supabase: SupabaseClient) => {
 
     const status = globals.statuses.get(channelName);
     if (status === "SUBSCRIBED" || status === "SUBSCRIBING") return;
-    // 이미 backoff 대기 중이거나 재연결이 진행 중이면 중복으로 끼어들지 않는다.
-    if (globals.connectTimeouts.has(channelName)) return;
 
     const userId = globals.channelUserIds.get(channelName);
     if (!userId) return;

--- a/src/shared/lib/realtime/townChannelManager.ts
+++ b/src/shared/lib/realtime/townChannelManager.ts
@@ -7,6 +7,16 @@ const MAX_AUTO_RECONNECT = 5;
 const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000];
 const CHANNEL_CLEANUP_DELAY_MS = 3000;
 const GLOBAL_KEY = "__townChannelState";
+// 채널 레벨 재연결이 MAX_AUTO_RECONNECT만큼 반복 실패하면, 채널이 아니라
+// 그 밑에 있는 realtime 소켓 자체가 손상된 것으로 보고 소켓을 통째로 재연결한다.
+// 이 값은 여러 채널이 거의 동시에 임계치를 넘겨도 소켓 리셋이 중복 실행되지 않도록 막는 디바운스 창이다.
+const SOCKET_RESET_DEDUPE_MS = 3000;
+// 소켓이 손상된 경우 "SUBSCRIBED -> CLOSED -> (재연결 성공) -> SUBSCRIBED -> CLOSED -> ..."처럼
+// 매번 재연결에는 성공하지만 곧바로 다시 끊기는 flapping 패턴으로 나타난다. 이 경우
+// SUBSCRIBED에 도달할 때마다 reconnectCount가 0으로 리셋되어 MAX_AUTO_RECONNECT에 영영 도달하지 못한다.
+// 그래서 "짧은 시간 안에 반복 실패"를 별도로 감지해 소켓 리셋을 트리거한다.
+const FLAP_STABILITY_MS = 8000;
+const MAX_FLAPS_BEFORE_SOCKET_RESET = 3;
 
 type ChannelStatus = string;
 type StatusObserver = (status: ChannelStatus, err?: Error) => void;
@@ -24,6 +34,13 @@ interface TownChannelGlobalState {
   subscribersCount: Map<string, number>;
   cleanupTimeouts: Map<string, ReturnType<typeof setTimeout>>;
   connectTimeouts: Map<string, ReturnType<typeof setTimeout>>;
+  lastSocketResetAt: number;
+  recentFailureCounts: Map<string, number>;
+  stabilityTimers: Map<string, ReturnType<typeof setTimeout>>;
+  // visibilitychange 리스너가 탭 복귀 시 재연결을 걸 때 필요한, 채널별 마지막 userId.
+  channelUserIds: Map<string, string>;
+  visibilityListenerRegistered: boolean;
+  lastSupabaseClient: SupabaseClient | null;
 }
 
 function getGlobals(): TownChannelGlobalState {
@@ -40,6 +57,12 @@ function getGlobals(): TownChannelGlobalState {
       subscribersCount: new Map(),
       cleanupTimeouts: new Map(),
       connectTimeouts: new Map(),
+      lastSocketResetAt: 0,
+      recentFailureCounts: new Map(),
+      stabilityTimers: new Map(),
+      channelUserIds: new Map(),
+      visibilityListenerRegistered: false,
+      lastSupabaseClient: null,
     };
   }
 
@@ -72,11 +95,38 @@ const clearCleanupTimeout = (channelName: string) => {
   }
 };
 
+const clearStabilityTimer = (channelName: string) => {
+  const timer = globals.stabilityTimers.get(channelName);
+  if (timer) {
+    clearTimeout(timer);
+    globals.stabilityTimers.delete(channelName);
+  }
+};
+
+/** SUBSCRIBED가 FLAP_STABILITY_MS 동안 유지되면 그제서야 flapping 카운트를 리셋한다. */
+const scheduleFlapStabilityReset = (channelName: string) => {
+  clearStabilityTimer(channelName);
+  const timer = setTimeout(() => {
+    globals.stabilityTimers.delete(channelName);
+    globals.recentFailureCounts.set(channelName, 0);
+  }, FLAP_STABILITY_MS);
+  globals.stabilityTimers.set(channelName, timer);
+};
+
+/** 실패를 기록하고, 짧은 시간 안에 반복 실패 중인지(flapping) 여부를 반환한다. */
+const recordChannelFailure = (channelName: string): boolean => {
+  clearStabilityTimer(channelName);
+  const count = (globals.recentFailureCounts.get(channelName) || 0) + 1;
+  globals.recentFailureCounts.set(channelName, count);
+  return count >= MAX_FLAPS_BEFORE_SOCKET_RESET;
+};
+
 const notifyStatusObservers = (channelName: string, status: ChannelStatus, err?: Error) => {
   globals.statuses.set(channelName, status);
 
   if (status === "SUBSCRIBED") {
     globals.reconnectCounts.set(channelName, 0);
+    scheduleFlapStabilityReset(channelName);
   }
 
   const observers = globals.statusObservers.get(channelName);
@@ -108,6 +158,47 @@ const destroyChannel = (supabase: SupabaseClient, channelName: string) => {
   notifyStatusObservers(channelName, "CLOSED");
 };
 
+/**
+ * 채널을 아무리 새로 만들어도 계속 실패한다면, 문제는 채널이 아니라 그 밑에 있는
+ * 하나의 WebSocket(소켓) 자체일 가능성이 높다. 이 경우 채널 객체를 갈아끼우는 것만으로는
+ * 절대 회복되지 않는다 (새로고침이 고치는 이유가 바로 완전히 새 소켓을 여는 것이기 때문).
+ * 그래서 소켓 자체를 끊었다 다시 연결하고, 현재 구독 중이던 채널을 전부 처음부터 다시 붙인다.
+ */
+const resetRealtimeSocket = (
+  supabase: SupabaseClient,
+  userId: string,
+  triggerChannelName: string,
+  reason: string,
+) => {
+  const now = Date.now();
+  if (now - globals.lastSocketResetAt < SOCKET_RESET_DEDUPE_MS) return;
+  globals.lastSocketResetAt = now;
+
+  console.warn(
+    `[townChannelManager] ${triggerChannelName}: ${reason}. ` +
+      `채널만 다시 만드는 대신 realtime 소켓 자체를 재연결합니다.`,
+  );
+
+  const channelNamesToResume = Array.from(globals.subscribersCount.entries())
+    .filter(([, count]) => count > 0)
+    .map(([name]) => name);
+
+  channelNamesToResume.forEach((name) => {
+    clearConnectTimeout(name);
+    destroyChannel(supabase, name);
+    globals.reconnectCounts.set(name, 0);
+    clearStabilityTimer(name);
+    globals.recentFailureCounts.set(name, 0);
+  });
+
+  supabase.realtime.disconnect();
+  supabase.realtime.connect();
+
+  channelNamesToResume.forEach((name) => {
+    scheduleConnect({ supabase, channelName: name, userId, immediate: true });
+  });
+};
+
 const scheduleConnect = ({
   supabase,
   channelName,
@@ -130,7 +221,12 @@ const scheduleConnect = ({
 
   const reconnectCount = globals.reconnectCounts.get(channelName) || 0;
   if (reconnectCount >= MAX_AUTO_RECONNECT) {
-    console.warn(`[townChannelManager] Max reconnect attempts reached for ${channelName}`);
+    resetRealtimeSocket(
+      supabase,
+      userId,
+      channelName,
+      `채널 레벨 재연결이 ${MAX_AUTO_RECONNECT}회 연속 실패함`,
+    );
     return;
   }
 
@@ -179,12 +275,28 @@ const scheduleConnect = ({
     notifyStatusObservers(channelName, "SUBSCRIBING");
 
     channel.subscribe((status, err) => {
+      // removeChannel()로 이 채널을 직접 제거했을 때도 내부적으로 이 콜백에 CLOSED가
+      // 한 번 더 뒤늦게 전달될 수 있다. 이미 다른 채널 객체로 교체(또는 삭제)된 이후의
+      // 이벤트라면 우리 재연결 로직을 새치기하지 못하도록 무시한다.
+      if (globals.channels.get(channelName) !== channel) return;
+
       notifyStatusObservers(channelName, status, err);
 
       if (
         (status === "CHANNEL_ERROR" || status === "TIMED_OUT" || status === "CLOSED") &&
         (globals.subscribersCount.get(channelName) || 0) > 0
       ) {
+        const isFlapping = recordChannelFailure(channelName);
+        if (isFlapping) {
+          resetRealtimeSocket(
+            supabase,
+            userId,
+            channelName,
+            `${FLAP_STABILITY_MS}ms 이내에 ${MAX_FLAPS_BEFORE_SOCKET_RESET}회 이상 반복 실패(flapping)함`,
+          );
+          return;
+        }
+
         scheduleConnect({ supabase, channelName, userId });
       }
     });
@@ -234,6 +346,9 @@ export const acquireTownChannel = ({
   const currentCount = globals.subscribersCount.get(channelName) || 0;
   globals.subscribersCount.set(channelName, currentCount + 1);
   clearCleanupTimeout(channelName);
+  globals.channelUserIds.set(channelName, userId);
+  globals.lastSupabaseClient = supabase;
+  ensureVisibilityListenerRegistered();
 
   scheduleConnect({
     supabase,
@@ -270,6 +385,9 @@ export const releaseTownChannel = ({
     globals.statusObservers.delete(channelName);
     globals.statuses.delete(channelName);
     globals.reconnectCounts.delete(channelName);
+    clearStabilityTimer(channelName);
+    globals.recentFailureCounts.delete(channelName);
+    globals.channelUserIds.delete(channelName);
   }, CHANNEL_CLEANUP_DELAY_MS);
 
   globals.cleanupTimeouts.set(channelName, timeout);
@@ -289,6 +407,44 @@ export const reconnectTownChannel = ({
 
   destroyChannel(supabase, channelName);
   globals.reconnectCounts.set(channelName, 0);
+  globals.channelUserIds.set(channelName, userId);
 
   scheduleConnect({ supabase, channelName, userId, immediate: true });
+};
+
+/**
+ * 탭이 숨겨졌다가 다시 보일 때(hidden -> visible), 현재 구독 중(subscribers > 0)이면서
+ * SUBSCRIBED가 아닌 채널만 즉시 재연결한다. 백그라운드 탭에서는 브라우저가 타이머를
+ * 강하게 스로틀링해서 backoff 재연결 자체가 늦게 발동할 수 있으므로, 탭 복귀는
+ * 대기 없이 바로 재연결을 시도할 좋은 신호다.
+ */
+const reconnectStaleChannelsOnVisible = (supabase: SupabaseClient) => {
+  globals.subscribersCount.forEach((count, channelName) => {
+    if (count <= 0) return;
+
+    const status = globals.statuses.get(channelName);
+    if (status === "SUBSCRIBED" || status === "SUBSCRIBING") return;
+    // 이미 backoff 대기 중이거나 재연결이 진행 중이면 중복으로 끼어들지 않는다.
+    if (globals.connectTimeouts.has(channelName)) return;
+
+    const userId = globals.channelUserIds.get(channelName);
+    if (!userId) return;
+
+    reconnectTownChannel({ supabase, channelName, userId });
+  });
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState !== "visible") return;
+  if (!globals.lastSupabaseClient) return;
+
+  reconnectStaleChannelsOnVisible(globals.lastSupabaseClient);
+};
+
+const ensureVisibilityListenerRegistered = () => {
+  if (globals.visibilityListenerRegistered) return;
+  if (typeof document === "undefined") return;
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  globals.visibilityListenerRegistered = true;
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

동시 접속자가 많아지거나, 탭을 오래 백그라운드에 두거나, 화면을 전환할 때 실시간 연결(town:main / village 채널)이 끊겼다 붙었다를 반복하던 문제(#150)를 개선했습니다.

- 음성 세션 정리: 새로고침이나 앱 강제 종료 시 음성(RealtimeKit) 세션이 정상 종료되지 않고 남아있어서, 재입장했을 때 목소리가 안 들리는 경우가 있었어요. 페이지 종료 시점(pagehide)에 연결 정리를 시도하는 코드를 추가했습니다.
- 채널 재연결 → 소켓 재연결로 승격: 예전에는 연결이 끊기면 "그 채널"만 다시 만들었는데, 채널 밑에 있는 연결 자체(소켓)가 문제인 경우엔 그 방식으로 절대 복구가 안 됐어요. 이제는 실패가 반복되거나 짧은 시간에 계속 끊겼다 붙는 게 감지되면, 채널이 아니라 연결 자체를 완전히 끊었다가 다시 여는 방식으로 승격시켰습니다.
- 탭 복귀 시 자동 재연결: 탭을 다른 곳에 뒀다가 돌아오면, 연결이 끊긴 채널이 있는지 확인해서 자동으로 재연결하도록 했습니다.
- 경쟁 상태 버그 수정: 위 작업 중 재연결 시도가 겹쳐서 발생하던 작은 버그를 하나 더 발견해서 같이 고쳤습니다.
- 트래픽 절감: 이동 시 위치 정보를 보내는 빈도를 초당 10회 → 4회로 줄였습니다. 다른 마을 사람도 보이는 기능은 유지하면서, 동시 접속 인원이 늘어나도(최대 50명 목표) 버틸 수 있게 하려는 목적입니다.

```
⚠️ 수동 테스트는 아직 진행 중입니다 — 아래 항목은 프리뷰 환경에서 시간을 들여 추가로 확인해야 합니다. 완료 전까지는 머지 보류를 권장합니다.

- 탭 전환 시 "연결됨/연결 안 됨" 표시가 깜빡이는지 (짧게/길게 각각)
- 맥에서 화면(Space) 전환 시에도 동일하게 유지되는지 (오늘 1시간 백그라운드 테스트는 진행했으나, 반복 재현은 더 필요)
- 그 외 실사용 중 발견되는 엣지케이스
```

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [x] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

(화면상 변화 없음, 콘솔 로그/연결 안정성 위주라 생략)


## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:** 
    - 5몇 번 실패하면 소켓 자체를 재연결할지" 기준값들(연속 실패 횟수, 짧은 시간 내 반복 실패 판단 기준 등)을 임의로 정했는데, 실제 운영 트래픽 기준으로도 적절한지 봐주세요.
    - 5탭 복귀 재연결 로직이 "이미 재연결 중이면 건너뛰기"만 처리했는데, 이 정도로 충분한지도 확인 부탁드려요.

- **함께 고민하고 싶은 부분:**
    - 지금은 이동 신호 빈도만 줄여서 대응했는데, 50명보다 훨씬 많아지면 "누가 접속해 있는지" 확인하는 신호(presence)도 자주 오가서 또 문제가 될 수 있어요. 인원이 더 늘어날 때 다시 봐야 할 부분입니다.
  - 원격 캐릭터 이동이 부드럽게 이어지지 않고 순간이동처럼 보이는 문제도 확인했는데, 이 부분은 윤우님과 이미 이야기가 된 사항이라 이번 PR 범위에는 포함하지 않았습니다.
  
- **기타 참고사항:**
    - Safari에서 음성 청취자 역할일 때 "스피커를 못 찾음" 에러가 뜨는 걸 발견했어요. 오늘 고친 것과는 무관한 별개 문제입니다. 캡처는 안 해뒀어서, 나중에 재현 후 별도 버그로 정리하겠습니다.
    - 위치 정보 조회 시 가끔 406 에러가 뜨는 것도 발견했는데, 이것도 오늘 작업과 무관한 기존 문제라 캡처 없이 넘어갔고 나중에 별도로 정리하겠습니다.
    - 위 수동 테스트(탭 전환/화면 전환 반복 확인)는 프리뷰에서 진행한 뒤 결과를 댓글로 남기겠습니다.

