### PR TITLE
[bug] 스피커 권한 검증  (#164)

### DIFF
--- a/src/app/api/voice/token/route.test.ts
+++ b/src/app/api/voice/token/route.test.ts
@@ -1,0 +1,114 @@
+import { createSupabaseServerClient } from "@/shared/config/supabase.server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "./route";
+
+const getUserMock = vi.fn();
+const cloudflareFetchMock = vi.fn();
+
+vi.mock("@/shared/config/supabase.server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+const createRequest = (body: Record<string, unknown> = {}) =>
+  new Request("http://localhost/api/voice/token", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-access-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+const cloudflareResponse = () =>
+  new Response(
+    JSON.stringify({
+      success: true,
+      data: { token: "token", id: "participant-id" },
+    }),
+    { status: 200 },
+  );
+
+describe("POST /api/voice/token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id");
+    vi.stubEnv("CLOUDFLARE_REALTIME_APP_ID", "app-id");
+    vi.stubEnv("CLOUDFLARE_REALTIME_MEETING_ID", "meeting-id");
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token");
+    vi.mocked(createSupabaseServerClient).mockReturnValue({
+      auth: { getUser: getUserMock },
+    } as never);
+    vi.stubGlobal("fetch", cloudflareFetchMock);
+    cloudflareFetchMock.mockResolvedValue(cloudflareResponse());
+  });
+
+  it("rejects requests without an authenticated Supabase user", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: new Error("unauthorized") });
+
+    const response = await POST(
+      new Request("http://localhost/api/voice/token", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(cloudflareFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("always issues the listener preset to a regular user despite isSpeaker input", async () => {
+    getUserMock.mockResolvedValue({
+      data: {
+        user: {
+          id: "verified-user-id",
+          user_metadata: { nickname: "일반 사용자" },
+          app_metadata: {},
+        },
+      },
+      error: null,
+    });
+
+    const response = await POST(
+      createRequest({
+        userId: "forged-user-id",
+        nickname: "조작된 닉네임",
+        isSpeaker: true,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      role: "listener",
+      presetName: "group_call_participant",
+    });
+    expect(cloudflareFetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: "일반 사용자",
+          preset_name: "group_call_participant",
+          custom_participant_id: "verified-user-id",
+        }),
+      }),
+    );
+  });
+
+  it("issues the speaker preset only to a user with the speaker app metadata role", async () => {
+    getUserMock.mockResolvedValue({
+      data: {
+        user: {
+          id: "speaker-user-id",
+          user_metadata: { nickname: "방송자" },
+          app_metadata: { role: "speaker" },
+        },
+      },
+      error: null,
+    });
+
+    const response = await POST(createRequest({ isSpeaker: false }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      role: "speaker",
+      presetName: "group_call_host",
+    });
+  });
+});

--- a/src/app/api/voice/token/route.ts
+++ b/src/app/api/voice/token/route.ts
@@ -1,4 +1,6 @@
 // src/app/api/voice/token/route.ts
+import { createSupabaseServerClient } from "@/shared/config/supabase.server";
+
 import { NextResponse } from "next/server";
 
 /** speaker용 Cloudflare Realtime Kit preset Name */
@@ -7,30 +9,46 @@ const SPEAKER_PRESET_NAME = "group_call_host";
 /** listener용 Cloudflare Realtime Kit preset Name */
 const LISTENER_PRESET_NAME = "group_call_participant";
 
-/** 음성 토큰 발급 요청 바디 */
-type VoiceTokenRequest = {
-  userId: string;
-  nickname: string;
-  isSpeaker?: boolean;
-};
-
 /**
  * 음성 채널 참여를 위한 Cloudflare Realtime Kit 토큰을 발급한다.
  *
  * speaker는 오디오 track을 publish할 수 있는 preset으로 발급하고,
  * listener는 subscribe만 가능한 preset으로 발급한다.
- *
- * TODO: 현재 isSpeaker를 클라이언트 요청값 그대로 사용하고 있다.
- * 프로덕션에서는 서버 측에서 speaker 권한을 검증해야 한다.
+ * 요청의 Bearer token을 Supabase에서 검증한 뒤,
+ * 인증된 사용자의 app_metadata.role로 speaker 여부를 판정한다.
+ * 클라이언트가 전달한 userId, nickname, isSpeaker는 권한 판정에 사용하지 않는다.
  */
 export async function POST(req: Request) {
   try {
-    const body = (await req.json()) as VoiceTokenRequest;
-    const { userId, nickname, isSpeaker = false } = body;
+    const accessToken = req.headers.get("authorization")?.match(/^Bearer\s+(.+)$/i)?.[1];
 
-    if (!userId || !nickname) {
-      return NextResponse.json({ error: "userId와 nickname은 필수입니다." }, { status: 400 });
+    if (!accessToken) {
+      return NextResponse.json({ error: "인증이 필요합니다." }, { status: 401 });
     }
+
+    const supabase = createSupabaseServerClient();
+
+    if (!supabase) {
+      return NextResponse.json({ error: "Supabase 환경변수가 누락되었습니다." }, { status: 500 });
+    }
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser(accessToken);
+
+    if (userError || !user) {
+      return NextResponse.json({ error: "인증된 사용자를 확인할 수 없습니다." }, { status: 401 });
+    }
+
+    const nickname = user.user_metadata?.nickname;
+
+    if (typeof nickname !== "string" || !nickname.trim()) {
+      return NextResponse.json({ error: "닉네임이 필요합니다." }, { status: 400 });
+    }
+
+    const isSpeaker = user.app_metadata?.role === "speaker";
+    const userId = user.id;
 
     const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
     const appId = process.env.CLOUDFLARE_REALTIME_APP_ID;
@@ -67,7 +85,6 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           error: "participant token 발급에 실패했습니다.",
-          detail: result,
         },
         { status: response.status || 500 },
       );
@@ -79,11 +96,10 @@ export async function POST(req: Request) {
       role: isSpeaker ? "speaker" : "listener",
       presetName,
     });
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       {
         error: "Unexpected server error",
-        detail: error instanceof Error ? error.message : String(error),
       },
       { status: 500 },
     );

--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -6,6 +6,7 @@ import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { useTownPanelToggleStore } from "@/features/panelToggle";
 import { useTownPresence } from "@/features/presence";
 import { SingleTownTabBlockedNotice, useSingleTownTabEntry } from "@/features/singleTownTab";
+import type { VoiceRole } from "@/features/voiceChat";
 import { useUserInfo } from "@/shared/hooks";
 import { useUserStore } from "@/shared/store/useUserStore";
 import { ChatPanel } from "@/widgets/chatPanel";
@@ -13,7 +14,7 @@ import { TownToolbar } from "@/widgets/townToolbar";
 import { TownVoiceSection } from "@/widgets/townVoiceSection";
 import { UsersPanel } from "@/widgets/usersPanel";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
@@ -66,7 +67,7 @@ function ActiveTownPage() {
   const { data: user, isLoading } = useUserInfo();
   const userNickname = user?.user_metadata?.nickname;
   const characterId = resolveCharacterId(user?.user_metadata?.characterId);
-  const isSpeaker = userNickname === process.env.NEXT_PUBLIC_SPEAKER_NICKNAME;
+  const [voiceRole, setVoiceRole] = useState<VoiceRole | null>(null);
   const { setUserProfile } = useUserStore();
   const activePanel = useTownPanelToggleStore((state) => state.activePanel);
   const resetMovement = useMovementStore((state) => state.reset);
@@ -123,9 +124,13 @@ function ActiveTownPage() {
       </div>
 
       {user?.id && userNickname ? (
-        <TownVoiceSection userId={user.id} userNickname={userNickname} isSpeaker={isSpeaker} />
+        <TownVoiceSection
+          userNickname={userNickname}
+          voiceRole={voiceRole}
+          onRoleChange={setVoiceRole}
+        />
       ) : null}
-      <TownToolbar isSpeaker={isSpeaker} />
+      <TownToolbar isSpeaker={voiceRole === "speaker"} />
     </div>
   );
 }

--- a/src/features/auth/api/ensureAnonymousSession.test.ts
+++ b/src/features/auth/api/ensureAnonymousSession.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const signInAnonymouslyMock = vi.fn();
+
+vi.mock("@/shared/config/supabase.client", () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock,
+      signInAnonymously: signInAnonymouslyMock,
+    },
+  },
+}));
+
+describe("ensureAnonymousSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the existing session without creating a new anonymous user", async () => {
+    getSessionMock.mockResolvedValue({
+      data: { session: { user: { id: "existing-user" } } },
+      error: null,
+    });
+
+    const { ensureAnonymousSession } = await import("./ensureAnonymousSession");
+
+    await ensureAnonymousSession();
+
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled();
+  });
+
+  it("creates an anonymous user when no session exists", async () => {
+    getSessionMock.mockResolvedValue({ data: { session: null }, error: null });
+    signInAnonymouslyMock.mockResolvedValue({ error: null });
+
+    const { ensureAnonymousSession } = await import("./ensureAnonymousSession");
+
+    await ensureAnonymousSession();
+
+    expect(signInAnonymouslyMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/auth/api/ensureAnonymousSession.ts
+++ b/src/features/auth/api/ensureAnonymousSession.ts
@@ -1,0 +1,20 @@
+import { supabase } from "@/shared/config/supabase.client";
+
+/** 기존 익명 세션을 유지하고, 세션이 없을 때만 새 익명 사용자를 생성한다. */
+export async function ensureAnonymousSession(): Promise<void> {
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    throw new Error(`익명 세션 확인에 실패했습니다: ${sessionError.message}`);
+  }
+
+  if (session) return;
+
+  const { error: signInError } = await supabase.auth.signInAnonymously();
+  if (signInError) {
+    throw new Error(`익명 로그인에 실패했습니다: ${signInError.message}`);
+  }
+}

--- a/src/features/auth/ui/NicknameForm.tsx
+++ b/src/features/auth/ui/NicknameForm.tsx
@@ -22,16 +22,15 @@ import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
+import { ensureAnonymousSession } from "../api/ensureAnonymousSession";
+
 interface EnterTownParams {
   nickname: string;
   characterId: CharacterId;
 }
 
 const handleEnterTown = async ({ nickname, characterId }: EnterTownParams) => {
-  const { error: signInError } = await supabase.auth.signInAnonymously();
-  if (signInError) {
-    throw new Error(`익명 로그인에 실패했습니다: ${signInError.message}`);
-  }
+  await ensureAnonymousSession();
 
   const { error: updateUserError } = await supabase.auth.updateUser({
     data: { nickname, characterId },

--- a/src/features/voiceChat/api/requestVoiceToken.test.ts
+++ b/src/features/voiceChat/api/requestVoiceToken.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { requestVoiceToken } from "./requestVoiceToken";
+
+const { getSessionMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+}));
+const fetchMock = vi.fn();
+
+vi.mock("@/shared/config/supabase.client", () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock,
+    },
+  },
+}));
+
+describe("requestVoiceToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "token",
+          participantId: "participant-id",
+          role: "listener",
+          presetName: "group_call_participant",
+        }),
+        { status: 200 },
+      ),
+    );
+  });
+
+  it("sends the Supabase access token without trusting client identity fields", async () => {
+    getSessionMock.mockResolvedValue({
+      data: { session: { access_token: "access-token" } },
+      error: null,
+    });
+
+    await requestVoiceToken();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/voice/token", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer access-token",
+      },
+    });
+  });
+
+  it("does not request a voice token without an authenticated session", async () => {
+    getSessionMock.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    await expect(requestVoiceToken()).rejects.toThrow("인증 세션이 없습니다.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/voiceChat/api/requestVoiceToken.ts
+++ b/src/features/voiceChat/api/requestVoiceToken.ts
@@ -1,20 +1,35 @@
-import { RequestVoiceTokenParams, RequestVoiceTokenResponse } from "../model/types";
+import { supabase } from "@/shared/config/supabase.client";
+
+import { RequestVoiceTokenResponse } from "../model/types";
 
 /**
  * 음성 채널 참여를 위한 토큰을 서버에 요청한다.
  *
  * /api/voice/token 엔드포인트를 호출하여
  * Cloudflare Realtime Kit 연결에 필요한 토큰과 참여자 정보를 반환받는다.
+ * 현재 Supabase 세션의 access token을 Authorization 헤더로 전달하며,
+ * 사용자 ID·닉네임·음성 역할은 요청 본문으로 전달하지 않는다.
+ * 인증 세션이 없으면 서버 요청을 보내지 않고 오류를 반환한다.
  */
-export async function requestVoiceToken(
-  params: RequestVoiceTokenParams,
-): Promise<RequestVoiceTokenResponse> {
+export async function requestVoiceToken(): Promise<RequestVoiceTokenResponse> {
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    throw new Error(`인증 세션 확인에 실패했습니다: ${sessionError.message}`);
+  }
+
+  if (!session?.access_token) {
+    throw new Error("인증 세션이 없습니다.");
+  }
+
   const response = await fetch("/api/voice/token", {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.access_token}`,
     },
-    body: JSON.stringify(params),
   });
 
   const result = await response.json();

--- a/src/features/voiceChat/hooks/useTownVoiceCallbacks.ts
+++ b/src/features/voiceChat/hooks/useTownVoiceCallbacks.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef } from "react";
 
+import type { VoiceRole } from "../model/types";
+
 /** TownVoiceClient가 외부 UI 상태와 제어 함수를 동기화하기 위해 호출하는 콜백 모음 */
 export interface TownVoiceCallbacks {
+  /** 서버에서 확정된 음성 역할이 변경될 때 호출된다. */
+  onRoleChange?: (role: VoiceRole | null) => void;
   /**
    * 음성 연결 상태가 변경될 때 호출된다.
    * connected가 true이면 연결 완료, false이면 연결 실패 또는 언마운트를 의미한다.
@@ -34,6 +38,7 @@ export interface TownVoiceCallbacks {
  */
 export function useTownVoiceCallbacks({
   onConnectionChange,
+  onRoleChange,
   onAudioEnabledChange,
   onAudioControllerChange,
   onListeningControllerChange,
@@ -46,6 +51,7 @@ export function useTownVoiceCallbacks({
    */
   const callbacksRef = useRef({
     onConnectionChange,
+    onRoleChange,
     onAudioEnabledChange,
     onAudioControllerChange,
     onListeningControllerChange,
@@ -57,6 +63,7 @@ export function useTownVoiceCallbacks({
   useEffect(() => {
     callbacksRef.current = {
       onConnectionChange,
+      onRoleChange,
       onAudioEnabledChange,
       onAudioControllerChange,
       onListeningControllerChange,
@@ -67,6 +74,10 @@ export function useTownVoiceCallbacks({
 
   const notifyConnectionChange = useCallback((connected: boolean) => {
     callbacksRef.current.onConnectionChange?.(connected);
+  }, []);
+
+  const notifyRoleChange = useCallback((role: VoiceRole | null) => {
+    callbacksRef.current.onRoleChange?.(role);
   }, []);
 
   const notifyAudioEnabledChange = useCallback((enabled: boolean) => {
@@ -97,6 +108,7 @@ export function useTownVoiceCallbacks({
 
   return {
     notifyConnectionChange,
+    notifyRoleChange,
     notifyAudioEnabledChange,
     notifyAudioControllerChange,
     notifyListeningControllerChange,

--- a/src/features/voiceChat/index.ts
+++ b/src/features/voiceChat/index.ts
@@ -2,4 +2,4 @@ export { requestVoiceToken } from "./api/requestVoiceToken";
 export { TownVoiceClient } from "./ui/TownVoiceClient";
 
 export type { TownVoiceClientProps } from "./ui/TownVoiceClient";
-export type { VoiceRole, RequestVoiceTokenParams, RequestVoiceTokenResponse } from "./model/types";
+export type { VoiceRole, RequestVoiceTokenResponse } from "./model/types";

--- a/src/features/voiceChat/model/types.ts
+++ b/src/features/voiceChat/model/types.ts
@@ -1,17 +1,11 @@
 /** 음성 채널 참여자 역할 */
 export type VoiceRole = "speaker" | "listener";
 
-/** 음성 토큰 발급 요청 파라미터 */
-export type RequestVoiceTokenParams = {
-  userId: string;
-  nickname: string;
-  isSpeaker?: boolean;
-};
-
 /** 음성 토큰 발급 응답 */
 export type RequestVoiceTokenResponse = {
   token: string;
   participantId: string;
+  /** 서버에서 인증 사용자 권한을 기준으로 확정한 음성 역할 */
   role: VoiceRole;
   presetName: string;
 };

--- a/src/features/voiceChat/model/voicePermissions.test.ts
+++ b/src/features/voiceChat/model/voicePermissions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveVoicePermissions } from "./voicePermissions";
+
+describe("resolveVoicePermissions", () => {
+  it("allows microphone use only for a speaker with a nickname", () => {
+    expect(resolveVoicePermissions("speaker", true)).toEqual({
+      isSpeaker: true,
+      canUseMic: true,
+      canListen: false,
+    });
+  });
+
+  it("keeps a speaker without a nickname from using the microphone", () => {
+    expect(resolveVoicePermissions("speaker", false)).toEqual({
+      isSpeaker: true,
+      canUseMic: false,
+      canListen: false,
+    });
+  });
+
+  it.each(["listener", null] as const)(
+    "keeps %s users from publishing and enables listening",
+    (role) => {
+      expect(resolveVoicePermissions(role, true)).toEqual({
+        isSpeaker: false,
+        canUseMic: false,
+        canListen: true,
+      });
+    },
+  );
+});

--- a/src/features/voiceChat/model/voicePermissions.ts
+++ b/src/features/voiceChat/model/voicePermissions.ts
@@ -1,0 +1,21 @@
+import type { VoiceRole } from "./types";
+
+export interface VoicePermissions {
+  isSpeaker: boolean;
+  canUseMic: boolean;
+  canListen: boolean;
+}
+
+/** 서버에서 확정된 음성 역할과 닉네임 상태를 UI·SDK 권한으로 변환한다. */
+export function resolveVoicePermissions(
+  role: VoiceRole | null,
+  hasNickname: boolean,
+): VoicePermissions {
+  const isSpeaker = role === "speaker";
+
+  return {
+    isSpeaker,
+    canUseMic: isSpeaker && hasNickname,
+    canListen: !isSpeaker,
+  };
+}

--- a/src/features/voiceChat/ui/TownVoiceClient.tsx
+++ b/src/features/voiceChat/ui/TownVoiceClient.tsx
@@ -69,6 +69,7 @@ export function TownVoiceClient({
   nickname,
   voiceRole,
   onConnectionChange,
+  onRoleChange,
   onAudioEnabledChange,
   onAudioControllerChange,
   onListeningControllerChange,
@@ -95,6 +96,7 @@ export function TownVoiceClient({
     notifyAudioTogglingChange,
   } = useTownVoiceCallbacks({
     onConnectionChange,
+    onRoleChange,
     onAudioEnabledChange,
     onAudioControllerChange,
     onListeningControllerChange,

--- a/src/features/voiceChat/ui/TownVoiceClient.tsx
+++ b/src/features/voiceChat/ui/TownVoiceClient.tsx
@@ -14,12 +14,13 @@ import { useEffect, useRef, useState } from "react";
 
 import { requestVoiceToken } from "../api/requestVoiceToken";
 import { TownVoiceCallbacks, useTownVoiceCallbacks } from "../hooks/useTownVoiceCallbacks";
+import type { VoiceRole } from "../model/types";
+import { resolveVoicePermissions } from "../model/voicePermissions";
 
 /** 타운 음성 방송에서 speaker 또는 listener로 연결하기 위한 props */
 export interface TownVoiceClientProps extends TownVoiceCallbacks {
-  userId: string;
   nickname: string;
-  isSpeaker: boolean;
+  voiceRole: VoiceRole | null;
 }
 
 /** 음성 채널 연결 진행 상태 */
@@ -65,9 +66,8 @@ function VoicePanel({
  * speaker로 확정된 경우에만 join 이후 마이크를 활성화한다.
  */
 export function TownVoiceClient({
-  userId,
   nickname,
-  isSpeaker,
+  voiceRole,
   onConnectionChange,
   onAudioEnabledChange,
   onAudioControllerChange,
@@ -87,6 +87,7 @@ export function TownVoiceClient({
   const isAudioTogglingRef = useRef(false);
   const {
     notifyConnectionChange,
+    notifyRoleChange,
     notifyAudioEnabledChange,
     notifyAudioControllerChange,
     notifyListeningControllerChange,
@@ -102,7 +103,7 @@ export function TownVoiceClient({
   });
 
   const hasNickname = nickname.trim().length > 0;
-  const canUseMic = hasNickname && isSpeaker;
+  const voicePermissions = resolveVoicePermissions(voiceRole, hasNickname);
 
   useEffect(() => {
     let isMounted = true;
@@ -117,6 +118,7 @@ export function TownVoiceClient({
       try {
         setStatus("requesting-token");
         setErrorMessage(null);
+        notifyRoleChange(null);
         notifyAudioEnabledChange(false);
         notifyAudioTogglingChange(false);
         notifyAudioControllerChange(false, null);
@@ -126,18 +128,16 @@ export function TownVoiceClient({
         setIsListeningEnabled(DEFAULT_LISTENING_ENABLED);
         notifyListeningEnabledChange(DEFAULT_LISTENING_ENABLED);
 
-        const tokenResponse = await requestVoiceToken({
-          userId,
-          nickname,
-          isSpeaker,
-        });
+        const tokenResponse = await requestVoiceToken();
+        const nextPermissions = resolveVoicePermissions(tokenResponse.role, hasNickname);
 
         if (!isMounted) return;
 
+        notifyRoleChange(tokenResponse.role);
         setStatus("initializing");
 
         const mediaHandler = await initRTKMedia({
-          audio: canUseMic,
+          audio: nextPermissions.canUseMic,
           video: false,
         });
 
@@ -174,7 +174,8 @@ export function TownVoiceClient({
           if (isAudioTogglingRef.current) return;
 
           const activeMeeting = meetingRef.current;
-          if (!activeMeeting || !canUseMic || !activeMeeting.self.roomJoined) return;
+          if (!activeMeeting || !nextPermissions.canUseMic || !activeMeeting.self.roomJoined)
+            return;
 
           isAudioTogglingRef.current = true;
           notifyAudioTogglingChange(true);
@@ -201,7 +202,7 @@ export function TownVoiceClient({
           notifyListeningEnabledChange(next);
         };
 
-        if (!isSpeaker) {
+        if (nextPermissions.canListen) {
           notifyListeningControllerChange(true, toggleLocalListening);
         }
 
@@ -212,7 +213,7 @@ export function TownVoiceClient({
         const keepAudioDisabled = ({ audioEnabled }: { audioEnabled: boolean }) => {
           notifyAudioEnabledChange(audioEnabled);
 
-          if (!canUseMic && audioEnabled) {
+          if (!nextPermissions.canUseMic && audioEnabled) {
             void initializedMeeting.self.disableAudio();
           }
         };
@@ -230,12 +231,15 @@ export function TownVoiceClient({
 
         if (!isMounted) return;
 
-        if (!canUseMic && initializedMeeting.self.audioEnabled) {
+        if (!nextPermissions.canUseMic && initializedMeeting.self.audioEnabled) {
           await initializedMeeting.self.disableAudio();
         }
 
-        notifyAudioControllerChange(canUseMic, canUseMic ? toggleLocalAudio : null);
-        if (canUseMic) {
+        notifyAudioControllerChange(
+          nextPermissions.canUseMic,
+          nextPermissions.canUseMic ? toggleLocalAudio : null,
+        );
+        if (nextPermissions.canUseMic) {
           notifyListeningControllerChange(false, null);
           try {
             await initializedMeeting.self.enableAudio();
@@ -260,6 +264,7 @@ export function TownVoiceClient({
         if (!isMounted) return;
 
         setStatus("error");
+        notifyRoleChange(null);
         notifyConnectionChange(false);
         notifyAudioEnabledChange(false);
         notifyAudioTogglingChange(false);
@@ -286,6 +291,7 @@ export function TownVoiceClient({
 
       meetingRef.current = null;
       notifyConnectionChange(false);
+      notifyRoleChange(null);
       notifyAudioEnabledChange(false);
       notifyAudioTogglingChange(false);
       notifyAudioControllerChange(false, null);
@@ -295,11 +301,10 @@ export function TownVoiceClient({
     };
   }, [
     initMeeting,
-    isSpeaker,
+    hasNickname,
     nickname,
-    userId,
-    canUseMic,
     notifyConnectionChange,
+    notifyRoleChange,
     notifyAudioEnabledChange,
     notifyAudioControllerChange,
     notifyListeningControllerChange,
@@ -312,7 +317,10 @@ export function TownVoiceClient({
       {errorMessage ? <p className="text-red-600">{errorMessage}</p> : null}
       {status === "connected" ? (
         <RealtimeKitProvider value={client}>
-          <VoicePanel isSpeaker={isSpeaker} isListeningEnabled={isListeningEnabled} />
+          <VoicePanel
+            isSpeaker={voicePermissions.isSpeaker}
+            isListeningEnabled={isListeningEnabled}
+          />
         </RealtimeKitProvider>
       ) : null}
     </>

--- a/src/shared/config/supabase.server.ts
+++ b/src/shared/config/supabase.server.ts
@@ -1,0 +1,24 @@
+import { SupabaseClient, createClient } from "@supabase/supabase-js";
+import "server-only";
+
+/**
+ * 서버 요청에서 access token을 검증하기 위한 Supabase 클라이언트를 생성한다.
+ *
+ * 서버 간 세션을 저장하거나 자동 갱신하지 않고, 요청마다 전달된 token 검증에만 사용한다.
+ * Supabase 환경변수가 없으면 클라이언트를 생성하지 않고 null을 반환한다.
+ */
+export const createSupabaseServerClient = (): SupabaseClient | null => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return null;
+  }
+
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+};

--- a/src/widgets/townVoiceSection/ui/TownVoiceSection.tsx
+++ b/src/widgets/townVoiceSection/ui/TownVoiceSection.tsx
@@ -2,14 +2,15 @@
 
 import { useTownPresenceStore } from "@/features/presence/model/useTownPresenceStore";
 import { TownVoiceClient } from "@/features/voiceChat";
+import type { VoiceRole } from "@/features/voiceChat";
 
 interface TownVoiceSectionProps {
-  userId: string;
   userNickname: string;
-  isSpeaker: boolean;
+  voiceRole: VoiceRole | null;
+  onRoleChange: (role: VoiceRole | null) => void;
 }
 
-export function TownVoiceSection({ userId, userNickname, isSpeaker }: TownVoiceSectionProps) {
+export function TownVoiceSection({ userNickname, voiceRole, onRoleChange }: TownVoiceSectionProps) {
   const setVoiceConnected = useTownPresenceStore((state) => state.setVoiceConnected);
   const setAudioEnabled = useTownPresenceStore((state) => state.setAudioEnabled);
   const setAudioController = useTownPresenceStore((state) => state.setAudioController);
@@ -19,9 +20,9 @@ export function TownVoiceSection({ userId, userNickname, isSpeaker }: TownVoiceS
 
   return (
     <TownVoiceClient
-      userId={userId}
       nickname={userNickname}
-      isSpeaker={isSpeaker}
+      voiceRole={voiceRole}
+      onRoleChange={onRoleChange}
       onConnectionChange={setVoiceConnected}
       onAudioEnabledChange={setAudioEnabled}
       onAudioControllerChange={setAudioController}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

이슈 #164 대응으로 음성 토큰 발급 시 클라이언트 요청값이 아닌 Supabase 인증 사용자와 서버 권한을 기준으로 speaker 권한을 검증하도록 수정했습니다.

기존에는 요청 본문의 `isSpeaker`, `userId`, `nickname`을 그대로 사용해 일반 사용자가 `isSpeaker: true`를 전송하면 스피커용 preset을 받을 수 있었습니다. 이번 변경에서는 서버가 Bearer 토큰으로 인증된 사용자를 조회하고, 해당 사용자의 `app_metadata.role`이 `speaker`인 경우에만 스피커 preset을 발급합니다.

주요 변경 내용은 다음과 같습니다.

- `/api/voice/token`에서 인증 토큰과 Supabase 사용자 검증
- `app_metadata.role: "speaker"` 기준의 speaker/listener preset 발급
- 클라이언트 요청에서 사용자 ID, 닉네임, `isSpeaker` 제거
- API 응답의 `role`을 기준으로 마이크 UI와 RealtimeKit 권한 동기화
- 기존 Supabase 세션이 있으면 익명 로그인을 다시 호출하지 않고 UID 유지
- 음성 권한·인증 세션·역할 계산에 대한 테스트 추가
- Supabase 서버 클라이언트에 `server-only` 적용 및 외부 API 상세 오류 비노출


기존 동작과 변경된 이후의 동작을 다음 표로 정리했습니다.

| 구분 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 스피커 입장 조건 | 스피커 닉네임으로 입장하면 누구나 스피커 가능 | 스피커 닉네임으로 입장하고 `app_metadata.role`이 `speaker`인 사용자만 스피커 가능 |
| 권한 확인 기준 | 클라이언트 요청값 기준 | 인증된 Supabase 사용자 정보 기준 |
| 재입장 | 입장할 때마다 새 익명 UID가 생성될 수 있음 | 기존 세션이 있으면 기존 UID 재사용 |

## 🔧 변경 유형

- [ ] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [x] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

<img width="379" height="167" alt="voice-token-401-unauthorized" src="https://github.com/user-attachments/assets/b4cdd49e-810d-4987-9de4-9b0176a57797" />
<img width="543" height="442" alt="08-06" src="https://github.com/user-attachments/assets/cc69c218-a1c5-4ce3-9069-bc5ed98eb33b" />



## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
- `/api/voice/token`이 요청 본문의 권한 값을 사용하지 않고 인증된 Supabase 사용자 정보를 기준으로 판단하는지 확인 부탁드립니다.
  - 클라이언트가 API 응답의 `role`을 기준으로 마이크 권한과 UI를 동기화하는지 확인 부탁드립니다.
  - 기존 세션 재입장 시 `auth/v1/signup`이 다시 호출되지 않고 기존 UID가 유지되는지 확인 부탁드립니다.
  
- **함께 고민하고 싶은 부분:**
  - 현재 단계에서는 저와 서윤님의 Supabase UID에만 관리자가 `app_metadata.role: "speaker"`를 수동으로 부여하는 방식을 제안합니다. 서윤님의 UID를 알려주시면 제가 추가해두려고 합니다.
  - UID는 다음 방법으로 확인할 수 있습니다.
  
    1. 도파민또에 입장하기 전 개발자 도구의 `Network` 탭을 엽니다.
    2. 닉네임을 입력하고 `타운 입장`을 클릭합니다.
    3. `auth/v1/user` 요청을 선택하고 `Response` 탭을 확인합니다.
    4. 응답의 `id` 값을 Supabase User ID로 확인합니다.
    
   - 이후 스피커를 추가할 때는 관리자 승인 후 해당 Supabase 사용자에게만 `app_metadata.role`을 부여하면 됩니다.
   - Supabase SQL Editor에서 다음 쿼리로 특정 UID에 스피커 권한을 부여할 수 있습니다.
     
      ```sql
      update auth.users
      set raw_app_meta_data =
        coalesce(raw_app_meta_data, '{}'::jsonb)
        || '{"role":"speaker"}'::jsonb
      where id = '부여받은 UID코드입력'
      returning id, raw_app_meta_data;
      ```
    - 현재 방식은 UID 확인과 관리자 수동 설정이 번거롭지만, 클라이언트에서 변경 가능한 닉네임이나 요청값만으로 스피커 권한을 부여하지 않는 보안 검증은 유지하는 것이 맞다고 판단했습니다. 
    - 운영 편의성을 높이려면 추후 `/admin/speakers`와 같은 관리자 전용 대시보드 페이지를 별도 이슈로 추가할 수 있습니다.
    - 관리자 페이지에서는 현재 접속자의 캐릭터·닉네임·UID·역할을 확인하고 스피커 권한을 부여하거나 회수하는 흐름을 제공할 수 있습니다.
    - 장기적으로는 관리자용 스피커 권한 관리 기능이나, 일반 사용자의 익명 로그인은 유지하면서 스피커만 승인된 이메일 계정으로 로그인하는 방식을 별도 이슈로 검토할 수 있습니다.
    
- **기타 참고사항:**
  - Supabase `user.id`는 사용자를 식별하고 `app_metadata.role`은 권한을 결정합니다. 닉네임은 표시와 사용자 확인을 위한 값일 뿐 권한 판정에 사용하지 않습니다.

