### PR TITLE
[bug] 캐릭터 렌더링 튕김 및 순간이동 버그  (#151)

### DIFF
--- a/src/app/town/page.tsx
+++ b/src/app/town/page.tsx
@@ -12,11 +12,15 @@ import { ChatPanel } from "@/widgets/chatPanel";
 import { TownToolbar } from "@/widgets/townToolbar";
 import { TownVoiceSection } from "@/widgets/townVoiceSection";
 import { UsersPanel } from "@/widgets/usersPanel";
+import { Wifi, WifiOff } from "lucide-react";
+import { toast } from "sonner";
 
 import { useEffect } from "react";
 
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
+
+const NETWORK_TOAST_ID = "town-network-status";
 
 const TownEngine = dynamic(
   () => import("@/features/movement/ui/TownEngine").then((mod) => mod.TownEngine),
@@ -78,6 +82,29 @@ function ActiveTownPage() {
       resetMovement();
     };
   }, [resetMovement]);
+
+  useEffect(() => {
+    const handleOffline = () => {
+      toast.error("인터넷 연결이 끊겼습니다. 재연결을 시도합니다.", {
+        id: NETWORK_TOAST_ID,
+        icon: <WifiOff aria-hidden="true" className="size-4 text-red-500" />,
+      });
+    };
+    const handleOnline = () => {
+      toast.info("인터넷 연결이 복구되었습니다. 타운 연결을 확인하는 중입니다.", {
+        id: NETWORK_TOAST_ID,
+        icon: <Wifi aria-hidden="true" className="size-4 text-green-500" />,
+      });
+    };
+
+    window.addEventListener("offline", handleOffline);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, []);
 
   /** 인증 사용자 닉네임을 클라이언트 store에 동기화한다. */
   useEffect(() => {

--- a/src/features/movement/hooks/useMovementSync.test.ts
+++ b/src/features/movement/hooks/useMovementSync.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const channelTrackMock = vi.fn().mockResolvedValue("ok");
+const channelSendMock = vi.fn().mockResolvedValue("ok");
+const presenceStateMock = vi.fn(() => ({}));
+const observePresenceMock = vi.fn();
+const observeStatusMock = vi.fn();
+const observeBroadcastMock = vi.fn();
+const removeRemotePlayerMock = vi.fn();
+const removeRemotePlayersOutsideVillagesMock = vi.fn();
+const setUserIdMock = vi.fn();
+const setNicknameMock = vi.fn();
+const setCharacterIdMock = vi.fn();
+
+let presenceHandler: ((event: string, payload?: unknown) => void) | undefined;
+
+const channel = {
+  presenceState: presenceStateMock,
+  send: channelSendMock,
+  track: channelTrackMock,
+  untrack: vi.fn().mockResolvedValue("ok"),
+};
+
+const movementState = {
+  villageId: "lobby",
+  nickname: "로컬 사용자",
+  characterId: "p-boy",
+  lastSyncedPosition: { x: 120, y: 240 },
+  localActionState: null,
+  remotePlayers: {},
+  setNickname: setNicknameMock,
+  setCharacterId: setCharacterIdMock,
+  setUserId: setUserIdMock,
+  updateRemotePlayer: vi.fn(),
+  removeRemotePlayer: removeRemotePlayerMock,
+  removeRemotePlayersOutsideVillages: removeRemotePlayersOutsideVillagesMock,
+};
+
+vi.mock("react", () => ({
+  useEffect: (effect: () => void) => effect(),
+  useRef: <T>(initialValue: T) => ({ current: initialValue }),
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: <T>(selector: T) => selector,
+}));
+
+vi.mock("@/app/providers/SupabaseProvider", () => ({
+  useSupabase: () => ({}),
+}));
+
+vi.mock("@/entities/village", () => ({
+  getVisibleVillages: () => ["lobby"],
+}));
+
+vi.mock("@/features/movement/model/config", () => ({
+  resolveCharacterId: (characterId: string) => characterId,
+}));
+
+vi.mock("@/features/movement/model/payload", () => ({
+  createPresencePayload: (payload: unknown) => payload,
+  createPresenceTrackSignature: () => "same-signature",
+  createSyncPositionPayload: (payload: unknown) => payload,
+}));
+
+vi.mock("@/features/movement/model/useMovementStore", () => ({
+  useMovementStore: Object.assign(
+    (selector: (state: typeof movementState) => unknown) => selector(movementState),
+    { getState: () => movementState },
+  ),
+}));
+
+vi.mock("@/shared/constants", () => ({
+  PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS: 0,
+}));
+
+vi.mock("@/shared/hooks/useDebouncedValue", () => ({
+  useDebouncedValue: (value: string) => value,
+}));
+
+vi.mock("@/shared/hooks/useUserInfo", () => ({
+  useUserInfo: () => ({ data: { id: "auth-user" } }),
+}));
+
+vi.mock("@/shared/lib/realtime", () => ({
+  getVillageChannelName: (villageId: string) => `village:${villageId}`,
+}));
+
+vi.mock("@/shared/lib/realtime/townChannelManager", () => ({
+  acquireTownChannel: () => vi.fn(),
+  getTownChannel: () => channel,
+  getTownChannelStatus: () => "SUBSCRIBED",
+  observeTownChannelBroadcast: (...args: unknown[]) => observeBroadcastMock(...args),
+  observeTownChannelPresence: (_channelName: string, handler: typeof presenceHandler) => {
+    presenceHandler = handler;
+    observePresenceMock();
+    return vi.fn();
+  },
+  observeTownChannelStatus: (...args: unknown[]) => observeStatusMock(...args),
+  reconnectTownChannel: vi.fn(),
+}));
+
+vi.mock("@/shared/store/useUserStore", () => ({
+  useUserStore: () => ({
+    selectedCharacterId: "p-boy",
+    userId: "local-user",
+    userNickname: "로컬 사용자",
+  }),
+}));
+
+describe("useMovementSync presence join", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    presenceHandler = undefined;
+  });
+
+  it("tracks the local latest position when a remote user joins", async () => {
+    const { useMovementSync } = await import("./useMovementSync");
+
+    useMovementSync();
+    const initialTrackCount = channelTrackMock.mock.calls.length;
+
+    presenceHandler?.("join", {
+      newPresences: [{ userId: "remote-user", villageId: "lobby", position: { x: 1, y: 2 } }],
+    });
+
+    expect(channelTrackMock).toHaveBeenCalledTimes(initialTrackCount + 1);
+    expect(channelTrackMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        position: { x: 120, y: 240 },
+        userId: "local-user",
+      }),
+    );
+  });
+
+  it("does not retrack when the joining presence belongs to the local user", async () => {
+    const { useMovementSync } = await import("./useMovementSync");
+
+    useMovementSync();
+    const initialTrackCount = channelTrackMock.mock.calls.length;
+
+    presenceHandler?.("join", {
+      newPresences: [{ userId: "local-user", villageId: "lobby", position: { x: 1, y: 2 } }],
+    });
+
+    expect(channelTrackMock).toHaveBeenCalledTimes(initialTrackCount);
+  });
+});

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -35,18 +35,20 @@ import { useEffect, useRef } from "react";
 import {
   LEGACY_PLAYER_MOVE_EVENT,
   PLAYER_MOVE_EVENT,
-  PRESENCE_LEAVE_REMOVAL_DELAY_MS,
+  REMOTE_PLAYER_REMOVAL_GRACE_MS,
   createMovementSyncState,
   getVillageSetKey,
 } from "../lib/movementSyncState";
+import {
+  cancelRemotePlayerRemoval,
+  scheduleRemotePlayerRemoval as scheduleRemotePlayerRemovalWithGrace,
+} from "../lib/remotePlayerRemoval";
 
 /**
  * 현재 village + 인접 village 범위를 기준으로 Realtime/Phaser visibility를 동기화한다.
  */
 export function useMovementSync(enabled = true) {
   const supabase = useSupabase();
-  // Presence leave 반영이 지연될 수 있어 remote player 제거 전 짧게 여러 번 재확인한다.
-  const MAX_REMOTE_PLAYER_REMOVAL_RETRIES = 8;
 
   const {
     villageId,
@@ -90,11 +92,10 @@ export function useMovementSync(enabled = true) {
     const syncState = syncStateRef.current;
 
     const clearPendingRemoval = (remoteUserId: string) => {
-      const timeout = syncState.pendingRemovalTimeouts.get(remoteUserId);
-      if (!timeout) return;
-
-      clearTimeout(timeout);
-      syncState.pendingRemovalTimeouts.delete(remoteUserId);
+      cancelRemotePlayerRemoval({
+        pendingRemovalTimeouts: syncState.pendingRemovalTimeouts,
+        remoteUserId,
+      });
     };
 
     const upsertVisibleRemotePlayer = (player: PresenceMetadata | SyncPositionPayload) => {
@@ -125,32 +126,22 @@ export function useMovementSync(enabled = true) {
           .some((presence) => presence.userId === remoteUserId);
       });
 
-    const scheduleRemotePlayerRemovalCheckWithRetry = (
-      remoteUserId: string,
-      retryCount: number,
-    ) => {
+    const scheduleRemotePlayerRemoval = (remoteUserId: string) => {
       if (!remoteUserId || remoteUserId === playerId) return;
 
-      clearPendingRemoval(remoteUserId);
-
-      const timeout = setTimeout(() => {
-        syncState.pendingRemovalTimeouts.delete(remoteUserId);
-
-        if (!isRemotePlayerStillPresent(remoteUserId)) {
+      scheduleRemotePlayerRemovalWithGrace({
+        pendingRemovalTimeouts: syncState.pendingRemovalTimeouts,
+        remoteUserId,
+        graceMs: REMOTE_PLAYER_REMOVAL_GRACE_MS,
+        isPresent: () => isRemotePlayerStillPresent(remoteUserId),
+        onConfirmed: () => {
           removeRemotePlayer(remoteUserId);
-          return;
-        }
-
-        if (retryCount >= MAX_REMOTE_PLAYER_REMOVAL_RETRIES) return;
-
-        scheduleRemotePlayerRemovalCheckWithRetry(remoteUserId, retryCount + 1);
-      }, PRESENCE_LEAVE_REMOVAL_DELAY_MS);
-
-      syncState.pendingRemovalTimeouts.set(remoteUserId, timeout);
+        },
+      });
     };
 
     const scheduleRemotePlayerRemovalCheck = (remoteUserId: string) => {
-      scheduleRemotePlayerRemovalCheckWithRetry(remoteUserId, 0);
+      scheduleRemotePlayerRemoval(remoteUserId);
     };
 
     const broadcastSyncLeave = (targetVillageId: VillageId) => {

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -140,26 +140,12 @@ export function useMovementSync(enabled = true) {
       if (!remoteUserId || remoteUserId === playerId) return;
       if (syncState.pendingRemovalTimeouts.has(remoteUserId)) return;
 
-      const removalScheduledAt = performance.now();
-      if (process.env.NODE_ENV === "development") {
-        console.info("[useMovementSync] remote player removal scheduled", {
-          graceMs: REMOTE_PLAYER_REMOVAL_GRACE_MS,
-          remoteUserId,
-        });
-      }
-
       scheduleRemotePlayerRemovalWithGrace({
         pendingRemovalTimeouts: syncState.pendingRemovalTimeouts,
         remoteUserId,
         graceMs: REMOTE_PLAYER_REMOVAL_GRACE_MS,
         isPresent: () => isRemotePlayerStillPresent(remoteUserId),
         onConfirmed: () => {
-          if (process.env.NODE_ENV === "development") {
-            console.info("[useMovementSync] remote player removal confirmed", {
-              elapsedMs: Math.round(performance.now() - removalScheduledAt),
-              remoteUserId,
-            });
-          }
           removeRemotePlayer(remoteUserId);
         },
       });

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -238,7 +238,7 @@ export function useMovementSync(enabled = true) {
       }
     };
 
-    const trackCurrentPresence = async (retryCount = 0) => {
+    const trackCurrentPresence = async (retryCount = 0, force = false) => {
       if (!supabase || !channelUserId || !playerId) return;
 
       const state = useMovementStore.getState();
@@ -261,7 +261,7 @@ export function useMovementSync(enabled = true) {
       });
 
       const payloadSignature = createPresenceTrackSignature(payload);
-      if (retryCount === 0 && syncState.lastPresenceSignature === payloadSignature) {
+      if (!force && retryCount === 0 && syncState.lastPresenceSignature === payloadSignature) {
         return;
       }
 
@@ -345,9 +345,18 @@ export function useMovementSync(enabled = true) {
           const newPresences = (payload as { newPresences?: PresenceMetadata[] } | undefined)
             ?.newPresences;
 
+          const hasRemoteJoin = newPresences?.some((presence) =>
+            Boolean(presence.userId && presence.userId !== playerId),
+          );
           newPresences?.forEach((presence) => {
             syncState.handlers.upsertVisibleRemotePlayer(presence);
           });
+
+          // 신규 사용자에게 기존 사용자의 최신 좌표를 전달하기 위해 Presence를 한 번 갱신한다.
+          // 이동 중 좌표 동기화는 player_move Broadcast가 담당하므로 이동마다 track하지 않는다.
+          if (hasRemoteJoin && syncState.trackedVillageId === targetVillageId) {
+            void syncState.handlers.trackCurrentPresence(0, true);
+          }
           return;
         }
 
@@ -370,9 +379,11 @@ export function useMovementSync(enabled = true) {
         if (event !== "sync-leave" || !payload) return;
 
         const leavePayload = payload as { userId?: string };
-        if (leavePayload.userId) {
-          syncState.handlers.scheduleRemotePlayerRemovalCheck(leavePayload.userId);
-        }
+        const remoteUserId = leavePayload.userId;
+        if (!remoteUserId || remoteUserId === playerId) return;
+
+        // 정상 퇴장 신호는 즉시 반영하고, 신호가 없으면 Presence 이탈이 fallback을 처리한다.
+        removeRemotePlayer(remoteUserId);
       });
 
       syncState.channelBindings.set(channelName, {

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -515,17 +515,7 @@ export function useMovementSync(enabled = true) {
 
     syncState.trackedVillageId = debouncedTrackedVillageId;
     void syncState.handlers.trackCurrentPresence();
-  }, [
-    channelUserId,
-    characterId,
-    debouncedTrackedVillageId,
-    enabled,
-    lastSyncedPosition,
-    localActionState,
-    nickname,
-    playerId,
-    supabase,
-  ]);
+  }, [channelUserId, debouncedTrackedVillageId, enabled, playerId, supabase]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -98,6 +98,11 @@ export function useMovementSync(enabled = true) {
       });
     };
 
+    const clearAllPendingRemovals = () => {
+      syncState.pendingRemovalTimeouts.forEach((timeout) => clearTimeout(timeout));
+      syncState.pendingRemovalTimeouts.clear();
+    };
+
     const upsertVisibleRemotePlayer = (player: PresenceMetadata | SyncPositionPayload) => {
       if (!player.userId || player.userId === playerId) return;
 
@@ -116,8 +121,15 @@ export function useMovementSync(enabled = true) {
       });
     };
 
-    const isRemotePlayerStillPresent = (remoteUserId: string) =>
-      Array.from(syncState.channelBindings.keys()).some((channelName) => {
+    const isRemotePlayerStillPresent = (remoteUserId: string) => {
+      const channelNames = Array.from(syncState.channelBindings.keys());
+      const isChannelReconnecting = channelNames.some(
+        (channelName) => getTownChannelStatus(channelName) !== "SUBSCRIBED",
+      );
+
+      if (isChannelReconnecting) return true;
+
+      return channelNames.some((channelName) => {
         const channel = getTownChannel(channelName);
         if (!channel) return false;
 
@@ -125,6 +137,7 @@ export function useMovementSync(enabled = true) {
           .flat()
           .some((presence) => presence.userId === remoteUserId);
       });
+    };
 
     const scheduleRemotePlayerRemoval = (remoteUserId: string) => {
       if (!remoteUserId || remoteUserId === playerId) return;
@@ -168,7 +181,7 @@ export function useMovementSync(enabled = true) {
         });
     };
 
-    const syncChannelSnapshot = (channelName: string) => {
+    const syncChannelSnapshot = (channelName: string, removeMissing = true) => {
       const channel = getTownChannel(channelName);
       if (!channel) return;
 
@@ -187,11 +200,13 @@ export function useMovementSync(enabled = true) {
 
       const prevPresenceUserIds =
         syncState.channelBindings.get(channelName)?.presenceUserIds ?? new Set<string>();
-      prevPresenceUserIds.forEach((remoteUserId) => {
-        if (!nextPresenceUserIds.has(remoteUserId)) {
-          scheduleRemotePlayerRemovalCheck(remoteUserId);
-        }
-      });
+      if (removeMissing) {
+        prevPresenceUserIds.forEach((remoteUserId) => {
+          if (!nextPresenceUserIds.has(remoteUserId)) {
+            scheduleRemotePlayerRemovalCheck(remoteUserId);
+          }
+        });
+      }
 
       const binding = syncState.channelBindings.get(channelName);
       if (binding) {
@@ -284,9 +299,12 @@ export function useMovementSync(enabled = true) {
       const releaseChannel = acquireTownChannel({ supabase, channelName, userId: channelUserId });
 
       const unsubscribeStatus = observeTownChannelStatus(channelName, (nextStatus) => {
-        if (nextStatus !== "SUBSCRIBED") return;
+        if (nextStatus !== "SUBSCRIBED") {
+          clearAllPendingRemovals();
+          return;
+        }
 
-        syncState.handlers.syncChannelSnapshot(channelName);
+        syncState.handlers.syncChannelSnapshot(channelName, false);
 
         if (useMovementStore.getState().villageId === targetVillageId) {
           void syncState.handlers.trackCurrentPresence();

--- a/src/features/movement/hooks/useMovementSync.ts
+++ b/src/features/movement/hooks/useMovementSync.ts
@@ -8,11 +8,7 @@ import {
   createPresenceTrackSignature,
   createSyncPositionPayload,
 } from "@/features/movement/model/payload";
-import {
-  PresenceMetadata,
-  SyncLeavePayload,
-  SyncPositionPayload,
-} from "@/features/movement/model/types";
+import { PresenceMetadata, SyncPositionPayload } from "@/features/movement/model/types";
 import { useMovementStore } from "@/features/movement/model/useMovementStore";
 import { PRESENCE_VILLAGE_TRACK_DEBOUNCE_MS } from "@/shared/constants";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
@@ -38,6 +34,7 @@ import {
   REMOTE_PLAYER_REMOVAL_GRACE_MS,
   createMovementSyncState,
   getVillageSetKey,
+  shouldInitializeRemotePlayerFromPresence,
 } from "../lib/movementSyncState";
 import {
   cancelRemotePlayerRemoval,
@@ -141,6 +138,15 @@ export function useMovementSync(enabled = true) {
 
     const scheduleRemotePlayerRemoval = (remoteUserId: string) => {
       if (!remoteUserId || remoteUserId === playerId) return;
+      if (syncState.pendingRemovalTimeouts.has(remoteUserId)) return;
+
+      const removalScheduledAt = performance.now();
+      if (process.env.NODE_ENV === "development") {
+        console.info("[useMovementSync] remote player removal scheduled", {
+          graceMs: REMOTE_PLAYER_REMOVAL_GRACE_MS,
+          remoteUserId,
+        });
+      }
 
       scheduleRemotePlayerRemovalWithGrace({
         pendingRemovalTimeouts: syncState.pendingRemovalTimeouts,
@@ -148,6 +154,12 @@ export function useMovementSync(enabled = true) {
         graceMs: REMOTE_PLAYER_REMOVAL_GRACE_MS,
         isPresent: () => isRemotePlayerStillPresent(remoteUserId),
         onConfirmed: () => {
+          if (process.env.NODE_ENV === "development") {
+            console.info("[useMovementSync] remote player removal confirmed", {
+              elapsedMs: Math.round(performance.now() - removalScheduledAt),
+              remoteUserId,
+            });
+          }
           removeRemotePlayer(remoteUserId);
         },
       });
@@ -172,7 +184,7 @@ export function useMovementSync(enabled = true) {
           event: "sync-leave",
           payload: {
             userId: playerId,
-          } satisfies SyncLeavePayload,
+          },
         })
         .then((res) => {
           if (res === "error") {
@@ -187,12 +199,24 @@ export function useMovementSync(enabled = true) {
 
       const presenceState = channel.presenceState<PresenceMetadata>();
       const nextPresenceUserIds = new Set<string>();
+      const knownRemotePlayerIds = new Set(Object.keys(useMovementStore.getState().remotePlayers));
 
       Object.values(presenceState)
         .flat()
         .forEach((presence) => {
-          if (presence.userId) {
-            nextPresenceUserIds.add(presence.userId);
+          if (!presence.userId) return;
+
+          nextPresenceUserIds.add(presence.userId);
+          clearPendingRemoval(presence.userId);
+
+          if (
+            !shouldInitializeRemotePlayerFromPresence({
+              currentUserId: playerId,
+              knownRemotePlayerIds,
+              presenceUserId: presence.userId,
+            })
+          ) {
+            return;
           }
 
           upsertVisibleRemotePlayer(presence);
@@ -345,7 +369,7 @@ export function useMovementSync(enabled = true) {
 
         if (event !== "sync-leave" || !payload) return;
 
-        const leavePayload = payload as SyncLeavePayload;
+        const leavePayload = payload as { userId?: string };
         if (leavePayload.userId) {
           syncState.handlers.scheduleRemotePlayerRemovalCheck(leavePayload.userId);
         }

--- a/src/features/movement/lib/TownScene.ts
+++ b/src/features/movement/lib/TownScene.ts
@@ -43,6 +43,8 @@ import { RemotePlayer } from "@/features/movement/model/types";
 import { CHARACTER_ACTION_CONFIGS } from "@/shared/constants";
 import * as Phaser from "phaser";
 
+const BACKGROUND_RESUME_DELTA_MS = 250;
+
 const CAPTURED_KEYS = "W,A,S,D,H,X,ZERO,UP,DOWN,LEFT,RIGHT,SPACE";
 const MAP_BACKGROUND_KEY = "town-map-background";
 const MAP_FRONT_KEY = "town-map-front";
@@ -66,7 +68,8 @@ export class TownScene extends Phaser.Scene {
   private unsubscribeStore?: () => void;
   private remotePlayerSprites: Map<string, Phaser.GameObjects.Sprite> = new Map();
   private remotePlayerNames: Map<string, Phaser.GameObjects.Text> = new Map();
-  private remotePlayerTargets: Map<string, { x: number; y: number }> = new Map();
+  private remotePlayerTargets: Map<string, { x: number; y: number; villageId: string }> = new Map();
+  private remotePlayerRenderedVillages: Map<string, string> = new Map();
   private remotePlayerActionSequences: Map<string, number> = new Map();
   private activeRemoteActions: Map<string, LocalActionId> = new Map();
   private playerNameLabel!: Phaser.GameObjects.Text;
@@ -327,6 +330,7 @@ export class TownScene extends Phaser.Scene {
       this.remotePlayerSprites.clear();
       this.remotePlayerNames.clear();
       this.remotePlayerTargets.clear();
+      this.remotePlayerRenderedVillages.clear();
       this.campfireAmbientController?.destroy();
     });
   };
@@ -349,6 +353,7 @@ export class TownScene extends Phaser.Scene {
         this.remotePlayerSprites.delete(userId);
         this.remotePlayerNames.delete(userId);
         this.remotePlayerTargets.delete(userId);
+        this.remotePlayerRenderedVillages.delete(userId);
         this.remotePlayerActionSequences.delete(userId);
         this.activeRemoteActions.delete(userId);
       }
@@ -404,7 +409,11 @@ export class TownScene extends Phaser.Scene {
 
       // 목표 위치 업데이트 (LERP용)
       if (data.position) {
-        this.remotePlayerTargets.set(userId, { x: data.position.x, y: data.position.y });
+        this.remotePlayerTargets.set(userId, {
+          x: data.position.x,
+          y: data.position.y,
+          villageId: data.villageId,
+        });
       }
 
       this.applyRemoteActionState(userId, sprite, data);
@@ -415,7 +424,7 @@ export class TownScene extends Phaser.Scene {
    * 매 프레임 호출되는 게임 루프
    * 타 플레이어 위치 보간(LERP), 애니메이션 처리 및 로컬 플레이어 입력 처리
    */
-  update = () => {
+  update = (_time: number, delta: number) => {
     const store = useMovementStore.getState();
 
     /**
@@ -428,10 +437,20 @@ export class TownScene extends Phaser.Scene {
         // 이동 거리 계산을 위해 이전 위치 저장
         const prevX = sprite.x;
         const prevY = sprite.y;
+        const previousVillageId = this.remotePlayerRenderedVillages.get(userId);
+        const shouldSnap =
+          (previousVillageId !== undefined && previousVillageId !== target.villageId) ||
+          delta > BACKGROUND_RESUME_DELTA_MS;
 
-        // 0.2는 보간 속도 (수치가 높을수록 빠름, 100ms 동기화 주기에 적합)
-        sprite.x = Phaser.Math.Linear(sprite.x, target.x, 0.2);
-        sprite.y = Phaser.Math.Linear(sprite.y, target.y, 0.2);
+        if (shouldSnap) {
+          sprite.setPosition(target.x, target.y);
+        } else {
+          const smoothingSpeed = 12;
+          const alpha = 1 - Math.exp((-smoothingSpeed * delta) / 1000);
+          sprite.x = Phaser.Math.Linear(sprite.x, target.x, alpha);
+          sprite.y = Phaser.Math.Linear(sprite.y, target.y, alpha);
+        }
+        this.remotePlayerRenderedVillages.set(userId, target.villageId);
 
         // 리모트 플레이어 애니메이션 처리
         const diffX = sprite.x - prevX;

--- a/src/features/movement/lib/movementSyncState.test.ts
+++ b/src/features/movement/lib/movementSyncState.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import * as movementSyncState from "./movementSyncState";
+
+type ShouldInitializeRemotePlayerFromPresence = (params: {
+  currentUserId?: string;
+  knownRemotePlayerIds: Set<string>;
+  presenceUserId?: string;
+}) => boolean;
+
+const shouldInitializeRemotePlayerFromPresence = (
+  movementSyncState as typeof movementSyncState & {
+    shouldInitializeRemotePlayerFromPresence?: ShouldInitializeRemotePlayerFromPresence;
+  }
+).shouldInitializeRemotePlayerFromPresence;
+
+describe("shouldInitializeRemotePlayerFromPresence", () => {
+  it("initializes only a remote player not already rendered", () => {
+    expect(shouldInitializeRemotePlayerFromPresence).toBeTypeOf("function");
+
+    expect(
+      shouldInitializeRemotePlayerFromPresence?.({
+        currentUserId: "local-user",
+        knownRemotePlayerIds: new Set(["remote-user"]),
+        presenceUserId: "remote-user",
+      }),
+    ).toBe(false);
+    expect(
+      shouldInitializeRemotePlayerFromPresence?.({
+        currentUserId: "local-user",
+        knownRemotePlayerIds: new Set(),
+        presenceUserId: "new-remote-user",
+      }),
+    ).toBe(true);
+    expect(
+      shouldInitializeRemotePlayerFromPresence?.({
+        currentUserId: "local-user",
+        knownRemotePlayerIds: new Set(),
+        presenceUserId: "local-user",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/movement/lib/movementSyncState.ts
+++ b/src/features/movement/lib/movementSyncState.ts
@@ -4,7 +4,7 @@ import type { ChannelBinding, MovementSyncHandlers, MovementSyncState } from "./
 
 export const PLAYER_MOVE_EVENT = "player_move";
 export const LEGACY_PLAYER_MOVE_EVENT = "sync-position";
-export const PRESENCE_LEAVE_REMOVAL_DELAY_MS = 250;
+export const REMOTE_PLAYER_REMOVAL_GRACE_MS = 2_500;
 
 const createInitialHandlers = () =>
   ({

--- a/src/features/movement/lib/movementSyncState.ts
+++ b/src/features/movement/lib/movementSyncState.ts
@@ -33,3 +33,20 @@ export const createMovementSyncState = (): MovementSyncState => ({
 });
 
 export const getVillageSetKey = (villages: VillageId[]) => [...new Set(villages)].sort().join("|");
+
+/**
+ * Presence sync에서는 처음 확인한 원격 플레이어만 초기 위치로 추가한다.
+ * 이미 렌더링 중인 플레이어의 최신 Broadcast 좌표는 유지한다.
+ */
+export const shouldInitializeRemotePlayerFromPresence = ({
+  currentUserId,
+  knownRemotePlayerIds,
+  presenceUserId,
+}: {
+  currentUserId?: string;
+  knownRemotePlayerIds: Set<string>;
+  presenceUserId?: string;
+}) =>
+  Boolean(
+    presenceUserId && presenceUserId !== currentUserId && !knownRemotePlayerIds.has(presenceUserId),
+  );

--- a/src/features/movement/lib/movementSyncState.ts
+++ b/src/features/movement/lib/movementSyncState.ts
@@ -4,7 +4,7 @@ import type { ChannelBinding, MovementSyncHandlers, MovementSyncState } from "./
 
 export const PLAYER_MOVE_EVENT = "player_move";
 export const LEGACY_PLAYER_MOVE_EVENT = "sync-position";
-export const REMOTE_PLAYER_REMOVAL_GRACE_MS = 2_500;
+export const REMOTE_PLAYER_REMOVAL_GRACE_MS = 8_000;
 
 const createInitialHandlers = () =>
   ({

--- a/src/features/movement/lib/remotePlayerRemoval.test.ts
+++ b/src/features/movement/lib/remotePlayerRemoval.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { cancelRemotePlayerRemoval, scheduleRemotePlayerRemoval } from "./remotePlayerRemoval";
+
+describe("scheduleRemotePlayerRemoval", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the player during the grace period", () => {
+    vi.useFakeTimers();
+    const pendingRemovalTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+    const onConfirmed = vi.fn();
+
+    scheduleRemotePlayerRemoval({
+      pendingRemovalTimeouts,
+      remoteUserId: "user-1",
+      graceMs: 2_500,
+      isPresent: () => true,
+      onConfirmed,
+    });
+
+    vi.advanceTimersByTime(2_500);
+
+    expect(onConfirmed).not.toHaveBeenCalled();
+    expect(pendingRemovalTimeouts).toHaveProperty("size", 0);
+  });
+
+  it("confirms removal after the grace period when the player is absent", () => {
+    vi.useFakeTimers();
+    const pendingRemovalTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+    const onConfirmed = vi.fn();
+
+    scheduleRemotePlayerRemoval({
+      pendingRemovalTimeouts,
+      remoteUserId: "user-1",
+      graceMs: 2_500,
+      isPresent: () => false,
+      onConfirmed,
+    });
+
+    vi.advanceTimersByTime(2_500);
+
+    expect(onConfirmed).toHaveBeenCalledOnce();
+    expect(pendingRemovalTimeouts).toHaveProperty("size", 0);
+  });
+
+  it("does not create a duplicate timer for the same player", () => {
+    vi.useFakeTimers();
+    const pendingRemovalTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+    const onConfirmed = vi.fn();
+    const params = {
+      pendingRemovalTimeouts,
+      remoteUserId: "user-1",
+      graceMs: 2_500,
+      isPresent: () => false,
+      onConfirmed,
+    };
+
+    scheduleRemotePlayerRemoval(params);
+    scheduleRemotePlayerRemoval(params);
+    vi.advanceTimersByTime(2_500);
+
+    expect(onConfirmed).toHaveBeenCalledOnce();
+  });
+
+  it("cancels removal when the player reappears during the grace period", () => {
+    vi.useFakeTimers();
+    const pendingRemovalTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+    const onConfirmed = vi.fn();
+
+    scheduleRemotePlayerRemoval({
+      pendingRemovalTimeouts,
+      remoteUserId: "user-1",
+      graceMs: 2_500,
+      isPresent: () => false,
+      onConfirmed,
+    });
+
+    cancelRemotePlayerRemoval({
+      pendingRemovalTimeouts,
+      remoteUserId: "user-1",
+    });
+
+    vi.advanceTimersByTime(2_500);
+
+    expect(onConfirmed).not.toHaveBeenCalled();
+    expect(pendingRemovalTimeouts).toHaveProperty("size", 0);
+  });
+});

--- a/src/features/movement/lib/remotePlayerRemoval.ts
+++ b/src/features/movement/lib/remotePlayerRemoval.ts
@@ -1,0 +1,41 @@
+interface ScheduleRemotePlayerRemovalParams {
+  pendingRemovalTimeouts: Map<string, ReturnType<typeof setTimeout>>;
+  remoteUserId: string;
+  graceMs: number;
+  isPresent: () => boolean;
+  onConfirmed: () => void;
+}
+
+interface CancelRemotePlayerRemovalParams {
+  pendingRemovalTimeouts: Map<string, ReturnType<typeof setTimeout>>;
+  remoteUserId: string;
+}
+
+export const scheduleRemotePlayerRemoval = ({
+  pendingRemovalTimeouts,
+  remoteUserId,
+  graceMs,
+  isPresent,
+  onConfirmed,
+}: ScheduleRemotePlayerRemovalParams) => {
+  if (pendingRemovalTimeouts.has(remoteUserId)) return;
+
+  const timeout = setTimeout(() => {
+    pendingRemovalTimeouts.delete(remoteUserId);
+
+    if (!isPresent()) onConfirmed();
+  }, graceMs);
+
+  pendingRemovalTimeouts.set(remoteUserId, timeout);
+};
+
+export const cancelRemotePlayerRemoval = ({
+  pendingRemovalTimeouts,
+  remoteUserId,
+}: CancelRemotePlayerRemovalParams) => {
+  const timeout = pendingRemovalTimeouts.get(remoteUserId);
+  if (!timeout) return;
+
+  clearTimeout(timeout);
+  pendingRemovalTimeouts.delete(remoteUserId);
+};

--- a/src/features/movement/lib/types.ts
+++ b/src/features/movement/lib/types.ts
@@ -8,7 +8,7 @@ export interface MovementSyncHandlers {
   detachVillageChannel: (targetVillageId: VillageId) => void;
   scheduleRemotePlayerRemovalCheck: (remoteUserId: string) => void;
   syncChannelSnapshot: (channelName: string, removeMissing?: boolean) => void;
-  trackCurrentPresence: (retryCount?: number) => Promise<void>;
+  trackCurrentPresence: (retryCount?: number, force?: boolean) => Promise<void>;
   upsertVisibleRemotePlayer: (player: PresenceMetadata | SyncPositionPayload) => void;
 }
 

--- a/src/features/movement/lib/types.ts
+++ b/src/features/movement/lib/types.ts
@@ -7,7 +7,7 @@ export interface MovementSyncHandlers {
   cleanupAllChannels: () => void;
   detachVillageChannel: (targetVillageId: VillageId) => void;
   scheduleRemotePlayerRemovalCheck: (remoteUserId: string) => void;
-  syncChannelSnapshot: (channelName: string) => void;
+  syncChannelSnapshot: (channelName: string, removeMissing?: boolean) => void;
   trackCurrentPresence: (retryCount?: number) => Promise<void>;
   upsertVisibleRemotePlayer: (player: PresenceMetadata | SyncPositionPayload) => void;
 }

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -46,7 +46,7 @@ interface MovementStore extends MovementState {
 export const useMovementStore = create<MovementStore>()(
   subscribeWithSelector((set, get) => {
     let lastFlushTime = 0;
-    // 전체 village 가시성(다른 마을 사람도 보임) 기준으로, 동시 접속 50명 규모에서도
+    // 250ms에서는 이동이 끊겨 보여 100ms를 유지한다. Presence track()은 별도로 제어한다.
     const FLUSH_INTERVAL = 100;
     let isSyncing = false;
     let flushTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/src/features/movement/model/useMovementStore.ts
+++ b/src/features/movement/model/useMovementStore.ts
@@ -47,8 +47,7 @@ export const useMovementStore = create<MovementStore>()(
   subscribeWithSelector((set, get) => {
     let lastFlushTime = 0;
     // 전체 village 가시성(다른 마을 사람도 보임) 기준으로, 동시 접속 50명 규모에서도
-    // player_move 트래픽이 realtime 소켓을 불안정하게 만들지 않도록 100ms(초당 10회) → 250ms(초당 4회)로 늘렸다.
-    const FLUSH_INTERVAL = 250;
+    const FLUSH_INTERVAL = 100;
     let isSyncing = false;
     let flushTimeout: ReturnType<typeof setTimeout> | null = null;
     /**


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

원격 캐릭터가 이동 중 사라지거나 순간이동하는 문제를 수정했습니다.

- Presence가 일시적으로 누락되어도 원격 캐릭터를 즉시 제거하지 않고 8초간 유지
- 원격 캐릭터 위치 보간을 프레임 기준에서 시간 기준으로 변경
- 빌리지 전환과 백그라운드 복귀 후 큰 좌표 차이는 즉시 스냅
- 채널 재연결 중 원격 캐릭터 상태 유지
- 이동·액션 변경과 Presence `track()` 호출을 분리해 호출 빈도 초과 방지
- 브라우저 네트워크 단절·복구 시 토스트 안내 추가
- 연결 상태 토스트에 `WifiOff`·`Wifi` 아이콘과 상태별 컬러 적용
- 동일 네트워크 토스트 ID를 사용해 반복 이벤트 시 중복 표시 방지

## 🔧 변경 유형

- [x] 🆕 새로운 기능
- [x] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] 🎨 코드 스타일링
- [ ] ♻️ 리팩토링
- [ ] 🔥 코드/파일 삭제

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/fa7108ad-b350-4e00-811e-610fe76f6b14

https://github.com/user-attachments/assets/f5fc5918-5507-4fca-a7bc-c5fbe9626e56

---

- 연결 끊김 토스트

<img width="999" height="670" alt="issue-151-offline-toast-red" src="https://github.com/user-attachments/assets/7c269a2a-329d-42ec-8897-4098e00af247" />

- 연결 복구 토스트
<img width="999" height="670" alt="issue-151-online-toast-green" src="https://github.com/user-attachments/assets/12fb6090-0dad-4c68-8225-ad1bd92051ca" />



## 💬 추가 전달사항

리뷰어에게 전하고 싶은 내용이나 특별한 요청사항을 자유롭게 작성해 주세요.

- **주의깊게 봐주길 원하는 부분:**
  - 이동 정보와 접속 상태 정보가 서로 영향을 주지 않도록 분리한 부분과, 원격 캐릭터의 위치 보간·빌리지 전환 시 스냅 처리 부분을 확인해주시면 좋겠습니다.
- **함께 고민하고 싶은 부분:**
  - Presence가 잠시 누락됐을 때 상대 캐릭터가 바로 사라졌다가 다시 나타나는 현상을 막기 위해 최대 8초간 기다립니다. 실제로 나간 사용자의 캐릭터가 최대 8초 동안 화면에 남을 수 있는데, 이 방식이 적절한지 함께 고민해보고 싶습니다. 정상적인 페이지 이탈을 알려주는 `sync-leave`를 받은 경우에만 즉시 제거하고, Presence 누락은 8초간 유예하는 방식도 생각해볼 수 있습니다. 다만 네트워크 단절이나 브라우저 강제 종료에서는 `sync-leave`가 전달되지 않을 수 있습니다.
- **기타 참고사항:**
  - 새로고침, 백그라운드 복귀, 네트워크 복구 상황을  확인했습니다. 
  - 연결 끊김·복구 토스트는 이슈의 핵심 작업에는 포함되지 않았지만, 연결 상태를 확인하기 쉽도록 함께 적용했습니다. 
  - 장시간 이동 이슈는 테스트 시간 동안 재현되지 않아 확인하지 못했습니다. 이후에도 계속 모니터링해볼 필요가 있을 것 같습니다.
